### PR TITLE
Use timezone-aware approval timestamps

### DIFF
--- a/app/api/v1/routers/__init__.py
+++ b/app/api/v1/routers/__init__.py
@@ -1,0 +1,11 @@
+from . import approval, download, health, history, jobs, profile, resumes
+
+__all__ = [
+    "approval",
+    "download",
+    "health",
+    "history",
+    "jobs",
+    "profile",
+    "resumes",
+]

--- a/app/api/v1/routers/approval.py
+++ b/app/api/v1/routers/approval.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from resume_core.models.approval import ApprovalWorkflow
+from resume_core.utils.errors import NotFoundError
+
+from .resumes import _resume_service
+
+router = APIRouter(tags=["approval"])
+
+
+class ApprovalRequest(BaseModel):
+    decision: str
+    comments: str | None = None
+
+
+@router.post("/resumes/{resume_id}/approve")
+async def approve_resume(resume_id: str, request: ApprovalRequest) -> dict[str, object]:
+    try:
+        workflow: ApprovalWorkflow = await _resume_service.approve_resume(
+            resume_id=resume_id,
+            decision=request.decision,
+            comments=request.comments,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - mapped to HTTP
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:  # invalid decision
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except NotFoundError as exc:  # pragma: no cover
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    latest_decision = workflow.history[-1].model_dump()
+    return {
+        "resume_id": workflow.resume_id,
+        "status": workflow.status,
+        "decision": latest_decision,
+        "history": [decision.model_dump() for decision in workflow.history],
+    }

--- a/app/api/v1/routers/download.py
+++ b/app/api/v1/routers/download.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from .resumes import _resume_service
+
+router = APIRouter(tags=["download"])
+
+
+@router.get("/resumes/{resume_id}/download")
+def download_resume(resume_id: str) -> dict[str, str]:
+    try:
+        return _resume_service.download_resume(resume_id)
+    except FileNotFoundError as exc:  # pragma: no cover - error mapping
+        raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/app/api/v1/routers/history.py
+++ b/app/api/v1/routers/history.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from .resumes import _resume_service
+
+router = APIRouter(tags=["history"])
+
+
+@router.get("/resumes/history")
+def list_history() -> dict[str, list]:
+    return {"items": _resume_service.list_history()}

--- a/app/api/v1/routers/jobs.py
+++ b/app/api/v1/routers/jobs.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from resume_core.agents.job_analysis_agent import JobAnalysisAgent
+
+router = APIRouter(tags=["jobs"])
+_job_agent = JobAnalysisAgent()
+
+
+class JobAnalysisRequest(BaseModel):
+    job_posting: str
+
+
+@router.post("/jobs/analyze")
+async def analyze_job(request: JobAnalysisRequest) -> dict[str, dict]:
+    analysis = await _job_agent.analyze(job_posting=request.job_posting)
+    return {"analysis": analysis.model_dump()}

--- a/app/api/v1/routers/profile.py
+++ b/app/api/v1/routers/profile.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from resume_core.models.profile import UserProfile
+from resume_core.services.profile_service import ProfileService
+
+router = APIRouter(tags=["profile"])
+_profile_service = ProfileService()
+
+
+@router.get("/profile")
+def get_profile() -> dict[str, dict]:
+    profile = _profile_service.load_profile()
+    return {"profile": profile.model_dump()}
+
+
+@router.put("/profile")
+def update_profile(payload: UserProfile) -> dict[str, dict]:
+    saved = _profile_service.save_profile(payload)
+    return {"profile": saved.model_dump()}

--- a/app/api/v1/routers/resumes.py
+++ b/app/api/v1/routers/resumes.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+
+from resume_core.services.resume_service import ResumeTailoringService
+
+router = APIRouter(tags=["resumes"])
+_resume_service = ResumeTailoringService()
+
+
+class ResumeTailorRequest(BaseModel):
+    job_posting: str = Field(..., min_length=10)
+    profile_overrides: dict[str, Any] | None = None
+
+
+@router.post("/resumes/tailor", status_code=status.HTTP_201_CREATED)
+async def tailor_resume(request: ResumeTailorRequest) -> dict[str, Any]:
+    if not request.job_posting.strip():
+        raise HTTPException(status_code=400, detail="Job posting text is required")
+    result = await _resume_service.tailor_resume(
+        job_posting=request.job_posting,
+        profile_overrides=request.profile_overrides,
+    )
+    return {
+        "resume_id": result.resume.resume_id,
+        "status": result.status,
+        "resume": result.resume.model_dump(),
+        "analysis": result.analysis.model_dump(),
+        "matching": result.matching.model_dump(),
+        "validation": result.validation.model_dump(),
+        "recommendation": result.recommendation.model_dump(),
+    }
+
+
+@router.get("/resumes/{resume_id}")
+def get_resume(resume_id: str) -> dict[str, Any]:
+    result = _resume_service.load_resume(resume_id)
+    return {
+        "resume_id": result.resume.resume_id,
+        "status": result.status,
+        "resume": result.resume.model_dump(),
+        "analysis": result.analysis.model_dump(),
+        "matching": result.matching.model_dump(),
+        "validation": result.validation.model_dump(),
+        "recommendation": result.recommendation.model_dump(),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1.routers import health
+from app.api.v1.routers import approval, download, health, history, jobs, profile, resumes
 from app.core.errors import install_error_handlers
 from app.core.settings import get_settings
 
@@ -24,6 +24,12 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(health.router, prefix="/api/v1")
+    app.include_router(profile.router, prefix="/api/v1")
+    app.include_router(jobs.router, prefix="/api/v1")
+    app.include_router(history.router, prefix="/api/v1")
+    app.include_router(resumes.router, prefix="/api/v1")
+    app.include_router(approval.router, prefix="/api/v1")
+    app.include_router(download.router, prefix="/api/v1")
 
     install_error_handlers(app)
 

--- a/src/resume_core/agents/__init__.py
+++ b/src/resume_core/agents/__init__.py
@@ -1,3 +1,16 @@
-from resume_core.agents.base_agent import Agent
+from resume_core.agents.base_agent import Agent, FunctionBackedAgent
+from resume_core.agents.human_interface_agent import HumanInterfaceAgent
+from resume_core.agents.job_analysis_agent import JobAnalysisAgent
+from resume_core.agents.profile_matching_agent import ProfileMatchingAgent
+from resume_core.agents.resume_generation_agent import ResumeGenerationAgent
+from resume_core.agents.validation_agent import ValidationAgent
 
-__all__ = ["Agent"]
+__all__ = [
+    "Agent",
+    "FunctionBackedAgent",
+    "JobAnalysisAgent",
+    "ProfileMatchingAgent",
+    "ResumeGenerationAgent",
+    "ValidationAgent",
+    "HumanInterfaceAgent",
+]

--- a/src/resume_core/agents/base_agent.py
+++ b/src/resume_core/agents/base_agent.py
@@ -1,4 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from pydantic_ai.models.function import FunctionModel
 
 
 class Agent:
@@ -20,3 +30,71 @@ class Agent:
             raise RuntimeError("Agent requires API key. Set OPENAI_API_KEY or mock in tests.")
 
         raise RuntimeError("Agent.run must be mocked in tests")
+
+
+OutputT = TypeVar("OutputT", bound=BaseModel)
+
+
+class FunctionBackedAgent(Generic[OutputT], ABC):
+    def __init__(self, *, name: str, instructions: str, output_model: type[OutputT]):
+        self._output_model = output_model
+        self._agent = PydanticAgent(
+            FunctionModel(function=self._function),
+            instructions=instructions,
+            name=name,
+        )
+
+    async def run(self, payload: Any) -> OutputT:
+        input_text = self._prepare_input_text(payload)
+        result = await self._agent.run(input_text)
+        return self._output_model.model_validate_json(result.output)
+
+    def _function(self, messages: list[Any], agent_info: Any) -> ModelResponse:
+        payload = self._extract_payload(messages)
+        output_model = self.build_output(payload)
+        return ModelResponse(parts=[TextPart(content=output_model.model_dump_json())])
+
+    def _extract_payload(self, messages: list[Any]) -> dict[str, Any]:
+        for message in reversed(messages):
+            if isinstance(message, ModelRequest):
+                for part in message.parts:
+                    if isinstance(part, UserPromptPart):
+                        content = part.content
+                        if isinstance(content, str):
+                            return self._parse_content(content)
+                        if isinstance(content, list) and content:
+                            combined = " ".join(str(item) for item in content)
+                            return self._parse_content(combined)
+        return {}
+
+    @staticmethod
+    def _prepare_input_text(payload: Any) -> str:
+        if isinstance(payload, BaseModel):
+            return payload.model_dump_json()
+        if isinstance(payload, str):
+            return payload
+        if isinstance(payload, bytes):
+            return payload.decode()
+        return json.dumps(payload, default=FunctionBackedAgent._json_default)
+
+    @staticmethod
+    def _parse_content(content: str) -> dict[str, Any]:
+        text = content.strip()
+        if not text:
+            return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return {"text": text}
+
+    @abstractmethod
+    def build_output(self, payload: dict[str, Any]) -> OutputT:
+        raise NotImplementedError
+
+    @staticmethod
+    def _json_default(value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, BaseModel):
+            return value.model_dump()
+        raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")

--- a/src/resume_core/agents/human_interface_agent.py
+++ b/src/resume_core/agents/human_interface_agent.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+from resume_core.agents.base_agent import FunctionBackedAgent
+from resume_core.models.approval import ReviewDecision
+from resume_core.models.resume import TailoredResume
+from resume_core.models.validation import ValidationResult
+
+
+class HumanInterfaceAgent(FunctionBackedAgent[ReviewDecision]):
+    def __init__(self) -> None:
+        super().__init__(
+            name="human-interface-agent",
+            instructions="Recommend the next action for a human reviewer based on validation output.",
+            output_model=ReviewDecision,
+        )
+
+    def build_output(self, payload: dict[str, Any]) -> ReviewDecision:
+        validation = ValidationResult.model_validate(payload.get("validation") or {})
+        resume = TailoredResume.model_validate(payload.get("resume") or {})
+        if validation.passed and validation.score >= 0.7:
+            return ReviewDecision(decision="approved", comments="Draft is ready for submission.")
+        if resume.summary and validation.passed:
+            return ReviewDecision(
+                decision="changes_requested",
+                comments="Consider refining highlighted skills before approval.",
+            )
+        return ReviewDecision(
+            decision="changes_requested",
+            comments="Resolve validation issues before seeking approval.",
+        )
+
+    async def review(
+        self,
+        *,
+        resume: TailoredResume,
+        validation: ValidationResult,
+    ) -> ReviewDecision:
+        payload = {
+            "resume": resume.model_dump(),
+            "validation": validation.model_dump(),
+        }
+        return await self.run(payload)

--- a/src/resume_core/agents/job_analysis_agent.py
+++ b/src/resume_core/agents/job_analysis_agent.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from resume_core.agents.base_agent import FunctionBackedAgent
+from resume_core.models.job_analysis import JobAnalysis, JobContext, JobRequirement
+
+
+class JobAnalysisAgent(FunctionBackedAgent[JobAnalysis]):
+    _REQUIREMENT_TEMPLATES = {
+        "python": {
+            "name": "Python Expertise",
+            "keywords": ["python", "backend"],
+            "importance": "high",
+            "description": "Build and maintain production Python services.",
+        },
+        "fastapi": {
+            "name": "FastAPI Services",
+            "keywords": ["fastapi", "api"],
+            "importance": "high",
+            "description": "Design and optimize FastAPI-based systems.",
+        },
+        "aws": {
+            "name": "Cloud Infrastructure (AWS)",
+            "keywords": ["aws", "cloud"],
+            "importance": "high",
+            "description": "Operate and improve workloads running on AWS.",
+        },
+        "azure": {
+            "name": "Cloud Infrastructure (Azure)",
+            "keywords": ["azure", "cloud"],
+            "importance": "medium",
+            "description": "Deploy and manage services in Azure environments.",
+        },
+        "sql": {
+            "name": "Data Querying",
+            "keywords": ["sql", "data"],
+            "importance": "medium",
+            "description": "Leverage SQL and analytics to inform decisions.",
+        },
+        "mentoring": {
+            "name": "Team Leadership",
+            "keywords": ["mentor", "mentoring", "lead"],
+            "importance": "medium",
+            "description": "Coach and develop junior teammates.",
+        },
+        "communication": {
+            "name": "Communication",
+            "keywords": ["communication", "stakeholder"],
+            "importance": "medium",
+            "description": "Communicate insights and plans clearly across teams.",
+        },
+        "cicd": {
+            "name": "Automation & CI/CD",
+            "keywords": ["ci/cd", "automation", "pipeline"],
+            "importance": "medium",
+            "description": "Maintain automated testing and deployment pipelines.",
+        },
+        "security": {
+            "name": "Security Mindset",
+            "keywords": ["security", "threat"],
+            "importance": "medium",
+            "description": "Design with security and reliability in mind.",
+        },
+    }
+
+    _STOPWORDS = {
+        "the",
+        "and",
+        "with",
+        "for",
+        "team",
+        "skills",
+        "ability",
+        "experience",
+        "years",
+        "including",
+        "strong",
+        "work",
+        "collaboration",
+        "develop",
+        "build",
+        "support",
+        "services",
+        "developers",
+        "needed",
+    }
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="job-analysis-agent",
+            instructions=(
+                "Analyze job posting text, extract the intended role, seniority, company references, "
+                "and synthesise structured requirement objects."
+            ),
+            output_model=JobAnalysis,
+        )
+
+    def build_output(self, payload: dict[str, Any]) -> JobAnalysis:
+        job_posting = str(payload.get("job_posting") or payload.get("text") or "").strip()
+        summary = self._build_summary(job_posting)
+        keywords = self._extract_keywords(job_posting)
+        requirements = self._build_requirements(job_posting, keywords)
+        context = JobContext(
+            role=self._extract_role(job_posting),
+            company=self._extract_company(job_posting),
+            seniority=self._infer_seniority(job_posting),
+            raw_text=job_posting,
+        )
+        return JobAnalysis(
+            summary=summary,
+            requirements=requirements,
+            keywords=keywords,
+            context=context,
+        )
+
+    def _build_summary(self, text: str) -> str:
+        if not text:
+            return "No job description provided."
+        sentences = re.split(r"[\n\.]+", text)
+        for sentence in sentences:
+            stripped = sentence.strip()
+            if stripped:
+                return stripped[:280]
+        return text[:280]
+
+    def _extract_keywords(self, text: str) -> list[str]:
+        normalized = text.lower()
+        collected: set[str] = set()
+        for template in self._REQUIREMENT_TEMPLATES.values():
+            for keyword in template["keywords"]:
+                if keyword in normalized:
+                    collected.add(keyword.replace("/", "/").lower())
+        if not collected:
+            words = re.findall(r"[a-zA-Z]{4,}", normalized)
+            for word in words:
+                if word not in self._STOPWORDS:
+                    collected.add(word)
+                    if len(collected) >= 10:
+                        break
+        ordered = sorted(collected)
+        return ordered
+
+    def _build_requirements(self, text: str, keywords: list[str]) -> list[JobRequirement]:
+        normalized = text.lower()
+        requirements: list[JobRequirement] = []
+        for template in self._REQUIREMENT_TEMPLATES.values():
+            if any(token in normalized for token in template["keywords"]):
+                requirements.append(
+                    JobRequirement(
+                        name=template["name"],
+                        importance=template["importance"],
+                        keywords=template["keywords"],
+                        description=template["description"],
+                    )
+                )
+        if not requirements:
+            fallback_keywords = keywords[:5] if keywords else ["collaboration", "delivery"]
+            requirements.append(
+                JobRequirement(
+                    name="Core Competencies",
+                    importance="medium",
+                    keywords=fallback_keywords,
+                    description="Identify core technical and collaboration capabilities for the role.",
+                )
+            )
+        return requirements
+
+    def _extract_role(self, text: str) -> str | None:
+        if not text:
+            return None
+        patterns = [
+            r"(?:seeking|seeks|seeking an|seeking a|looking for an|looking for a|hiring an|hiring a|need an|need a)\s+(?P<title>[^\n,\.]+)",
+            r"join our\s+(?P<title>[a-zA-Z0-9 /&-]+)\s+team",
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, text, flags=re.IGNORECASE)
+            if match:
+                return match.group("title").strip().title()
+        first_line = text.splitlines()[0] if text.splitlines() else text
+        first_sentence = re.split(r"[\.!?]", first_line)[0]
+        cleaned = first_sentence.replace("We are", "").replace("Join", "").strip()
+        return cleaned.title() if cleaned else None
+
+    def _extract_company(self, text: str) -> str | None:
+        if not text:
+            return None
+        match = re.search(r"join (?:our|the) ([a-zA-Z0-9 &-]+) team", text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1).strip().title()
+        match = re.search(r"at ([A-Z][A-Za-z0-9 &-]+)", text)
+        if match:
+            return match.group(1).strip()
+        return None
+
+    def _infer_seniority(self, text: str) -> str | None:
+        lowered = text.lower()
+        for level in ["principal", "staff", "senior", "lead", "junior"]:
+            if level in lowered:
+                return level
+        return None
+
+    async def analyze(self, *, job_posting: str) -> JobAnalysis:
+        return await self.run({"job_posting": job_posting})

--- a/src/resume_core/agents/profile_matching_agent.py
+++ b/src/resume_core/agents/profile_matching_agent.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any
+
+from resume_core.agents.base_agent import FunctionBackedAgent
+from resume_core.models.job_analysis import JobAnalysis
+from resume_core.models.matching import GapAnalysis, MatchingResult, SkillMatch
+from resume_core.models.profile import UserProfile
+
+
+class ProfileMatchingAgent(FunctionBackedAgent[MatchingResult]):
+    def __init__(self) -> None:
+        super().__init__(
+            name="profile-matching-agent",
+            instructions="Match job requirements to stored profile data and highlight strengths and gaps.",
+            output_model=MatchingResult,
+        )
+
+    def build_output(self, payload: dict[str, Any]) -> MatchingResult:
+        profile = UserProfile.model_validate(payload.get("profile") or {})
+        analysis = JobAnalysis.model_validate(payload.get("analysis") or {})
+        profile_keywords = self._collect_profile_keywords(profile)
+        matches: list[SkillMatch] = []
+        gaps: list[GapAnalysis] = []
+        scores: list[float] = []
+
+        for requirement in analysis.requirements:
+            matched = [
+                keyword
+                for keyword in requirement.keywords
+                if self._matches_keyword(keyword, profile_keywords)
+            ]
+            if matched:
+                score = min(1.0, len(matched) / max(len(requirement.keywords), 1))
+                scores.append(score)
+                matches.append(
+                    SkillMatch(
+                        requirement=requirement.name,
+                        matched_items=matched,
+                        match_score=score,
+                    )
+                )
+            else:
+                scores.append(0.0)
+                gaps.append(
+                    GapAnalysis(
+                        requirement=requirement.name,
+                        missing_skills=requirement.keywords,
+                    )
+                )
+
+        overall_score = round(sum(scores) / max(len(scores), 1), 2)
+        recommendations = self._build_recommendations(matches, gaps)
+        return MatchingResult(
+            overall_score=overall_score,
+            matched_skills=matches,
+            gaps=gaps,
+            recommendations=recommendations,
+        )
+
+    def _collect_profile_keywords(self, profile: UserProfile) -> set[str]:
+        keywords: set[str] = set()
+        if profile.summary:
+            keywords.update(word.lower() for word in profile.summary.split())
+        for skill in profile.skills:
+            keywords.add(skill.name.lower())
+            if skill.level:
+                keywords.add(skill.level.lower())
+        for experience in profile.experience:
+            keywords.add(experience.role.lower())
+            for skill in experience.skills:
+                keywords.add(skill.lower())
+            for achievement in experience.achievements:
+                keywords.update(word.lower() for word in achievement.description.split())
+        return keywords
+
+    def _matches_keyword(self, keyword: str, keywords: set[str]) -> bool:
+        normalized = keyword.lower()
+        return normalized in keywords or any(normalized in value for value in keywords)
+
+    def _build_recommendations(
+        self, matches: list[SkillMatch], gaps: list[GapAnalysis]
+    ) -> list[str]:
+        recommendations: list[str] = []
+        if matches:
+            top_match = max(matches, key=lambda item: item.match_score)
+            recommendations.append(
+                f"Highlight {', '.join(sorted(top_match.matched_items))} in your summary."
+            )
+        for gap in gaps:
+            recommendations.append(
+                f"Prepare examples addressing {gap.requirement.lower()} requirements."
+            )
+        if not recommendations:
+            recommendations.append("Profile aligns strongly with the role requirements.")
+        return recommendations
+
+    async def match(self, *, profile: UserProfile, analysis: JobAnalysis) -> MatchingResult:
+        payload = {"profile": profile.model_dump(), "analysis": analysis.model_dump()}
+        return await self.run(payload)

--- a/src/resume_core/agents/resume_generation_agent.py
+++ b/src/resume_core/agents/resume_generation_agent.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from resume_core.agents.base_agent import FunctionBackedAgent
+from resume_core.models.job_analysis import JobAnalysis
+from resume_core.models.matching import MatchingResult
+from resume_core.models.profile import UserProfile
+from resume_core.models.resume import ContentOptimization, ResumeSection, TailoredResume
+
+
+class ResumeGenerationAgent(FunctionBackedAgent[TailoredResume]):
+    def __init__(self) -> None:
+        super().__init__(
+            name="resume-generation-agent",
+            instructions="Generate a resume draft tailored to the provided job analysis and profile data.",
+            output_model=TailoredResume,
+        )
+
+    def build_output(self, payload: dict[str, Any]) -> TailoredResume:
+        profile = UserProfile.model_validate(payload.get("profile") or {})
+        analysis = JobAnalysis.model_validate(payload.get("analysis") or {})
+        matching = MatchingResult.model_validate(payload.get("matching") or {})
+
+        job_title = analysis.context.role or "Tailored Resume"
+        matched_keywords = {
+            item for match in matching.matched_skills for item in match.matched_items
+        }
+        summary = self._compose_summary(profile.summary, matched_keywords, job_title)
+        sections = self._build_sections(profile, matched_keywords)
+        markdown = self._compose_markdown(profile, job_title, summary, sections, matched_keywords)
+        optimization = ContentOptimization(
+            focus_keywords=sorted(matched_keywords)[:10],
+            readability_score=0.78 if summary else 0.65,
+            action_verbs_used=["Led", "Delivered", "Optimized"],
+        )
+        return TailoredResume(
+            resume_id=str(uuid4()),
+            job_title=job_title,
+            summary=summary,
+            sections=sections,
+            markdown=markdown,
+            created_at=datetime.now(UTC),
+            optimization=optimization,
+            metadata={"matched_keywords": sorted(matched_keywords)},
+        )
+
+    def _compose_summary(
+        self, profile_summary: str, matched_keywords: set[str], job_title: str
+    ) -> str:
+        highlights = (
+            ", ".join(sorted(matched_keywords)) if matched_keywords else "impactful outcomes"
+        )
+        if profile_summary:
+            return f"{profile_summary.strip()} Tailored for a {job_title} role with emphasis on {highlights}."
+        return f"Experienced professional tailored for {job_title} opportunities with focus on {highlights}."
+
+    def _build_sections(
+        self, profile: UserProfile, matched_keywords: set[str]
+    ) -> list[ResumeSection]:
+        experience_lines: list[str] = []
+        for experience in profile.experience:
+            period = f"{experience.start_date} – {experience.end_date or 'Present'}"
+            experience_lines.append(f"### {experience.role} · {experience.company}")
+            experience_lines.append(period)
+            for achievement in experience.achievements:
+                experience_lines.append(f"- {achievement.description}")
+            if experience.skills:
+                highlight = ", ".join(experience.skills)
+                experience_lines.append(f"- Tools: {highlight}")
+            experience_lines.append("")
+        skills_lines = ["- " + skill.name for skill in profile.skills] or ["- Add specific skills"]
+        if matched_keywords:
+            skills_lines.append("- Focus: " + ", ".join(sorted(matched_keywords)))
+        sections = [
+            ResumeSection(title="Professional Summary", content=profile.summary or ""),
+            ResumeSection(title="Experience", content="\n".join(experience_lines).strip()),
+            ResumeSection(title="Skills", content="\n".join(skills_lines).strip()),
+        ]
+        return sections
+
+    def _compose_markdown(
+        self,
+        profile: UserProfile,
+        job_title: str,
+        summary: str,
+        sections: list[ResumeSection],
+        matched_keywords: set[str],
+    ) -> str:
+        contact = profile.contact
+        header_name = contact.name or "Candidate"
+        lines: list[str] = [f"# {header_name}"]
+        contact_bits = [contact.email, contact.phone, contact.location]
+        contact_line = " | ".join(bit for bit in contact_bits if bit)
+        if contact_line:
+            lines.append(contact_line)
+        lines.append("")
+        lines.append(f"**{job_title}**")
+        lines.append("")
+        lines.append(summary)
+        lines.append("")
+        for section in sections:
+            if section.content:
+                lines.append(f"## {section.title}")
+                lines.append(section.content)
+                lines.append("")
+        if matched_keywords:
+            lines.append("## Keywords for ATS")
+            lines.append(", ".join(sorted(matched_keywords)))
+            lines.append("")
+        return "\n".join(line for line in lines if line is not None).strip()
+
+    async def generate(
+        self,
+        *,
+        profile: UserProfile,
+        analysis: JobAnalysis,
+        matching: MatchingResult,
+    ) -> TailoredResume:
+        payload = {
+            "profile": profile.model_dump(),
+            "analysis": analysis.model_dump(),
+            "matching": matching.model_dump(),
+        }
+        return await self.run(payload)

--- a/src/resume_core/agents/validation_agent.py
+++ b/src/resume_core/agents/validation_agent.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any
+
+from resume_core.agents.base_agent import FunctionBackedAgent
+from resume_core.models.job_analysis import JobAnalysis
+from resume_core.models.matching import MatchingResult
+from resume_core.models.resume import TailoredResume
+from resume_core.models.validation import ValidationIssue, ValidationResult
+
+
+class ValidationAgent(FunctionBackedAgent[ValidationResult]):
+    def __init__(self) -> None:
+        super().__init__(
+            name="validation-agent",
+            instructions="Validate tailored resumes for completeness, alignment, and data quality.",
+            output_model=ValidationResult,
+        )
+
+    def build_output(self, payload: dict[str, Any]) -> ValidationResult:
+        resume = TailoredResume.model_validate(payload.get("resume") or {})
+        matching = MatchingResult.model_validate(payload.get("matching") or {})
+        analysis = JobAnalysis.model_validate(payload.get("analysis") or {})
+
+        issues: list[ValidationIssue] = []
+        score = 0.0
+
+        if resume.summary.strip():
+            score += 0.35
+        else:
+            issues.append(
+                ValidationIssue(
+                    code="missing_summary",
+                    field="summary",
+                    message="Resume summary is empty",
+                    severity="error",
+                )
+            )
+
+        if resume.sections and all(section.content.strip() for section in resume.sections):
+            score += 0.25
+        else:
+            issues.append(
+                ValidationIssue(
+                    code="empty_sections",
+                    field="sections",
+                    message="One or more sections require additional detail",
+                    severity="warning",
+                )
+            )
+
+        if matching.overall_score >= 0.3:
+            score += 0.3
+        else:
+            issues.append(
+                ValidationIssue(
+                    code="low_alignment",
+                    field="matching.overall_score",
+                    message="Profile alignment with requirements is low",
+                    severity="warning",
+                )
+            )
+
+        if analysis.requirements and not matching.matched_skills:
+            issues.append(
+                ValidationIssue(
+                    code="missing_matches",
+                    field="matching.matched_skills",
+                    message="No skills matched the role requirements",
+                    severity="error",
+                )
+            )
+        else:
+            score += 0.1
+
+        passed = all(issue.severity != "error" for issue in issues)
+        final_score = round(min(1.0, max(score, matching.overall_score)), 2)
+        if not issues:
+            final_score = round(min(1.0, matching.overall_score + 0.2), 2)
+        return ValidationResult(passed=passed, issues=issues, score=final_score)
+
+    async def evaluate(
+        self,
+        *,
+        resume: TailoredResume,
+        matching: MatchingResult,
+        analysis: JobAnalysis,
+    ) -> ValidationResult:
+        payload = {
+            "resume": resume.model_dump(),
+            "matching": matching.model_dump(),
+            "analysis": analysis.model_dump(),
+        }
+        return await self.run(payload)

--- a/src/resume_core/models/__init__.py
+++ b/src/resume_core/models/__init__.py
@@ -1,0 +1,41 @@
+from .approval import ApprovalWorkflow, ReviewDecision
+from .job_analysis import JobAnalysis, JobContext, JobRequirement
+from .matching import GapAnalysis, MatchingResult, SkillMatch
+from .profile import (
+    CertificationEntry,
+    ContactInfo,
+    EducationEntry,
+    ExperienceAchievement,
+    LanguageEntry,
+    ProjectEntry,
+    SkillEntry,
+    UserProfile,
+    WorkExperience,
+)
+from .resume import ContentOptimization, ResumeSection, TailoredResume
+from .validation import ValidationIssue, ValidationResult
+
+__all__ = [
+    "ApprovalWorkflow",
+    "ReviewDecision",
+    "JobAnalysis",
+    "JobContext",
+    "JobRequirement",
+    "GapAnalysis",
+    "MatchingResult",
+    "SkillMatch",
+    "CertificationEntry",
+    "ContactInfo",
+    "EducationEntry",
+    "ExperienceAchievement",
+    "LanguageEntry",
+    "ProjectEntry",
+    "SkillEntry",
+    "UserProfile",
+    "WorkExperience",
+    "ContentOptimization",
+    "ResumeSection",
+    "TailoredResume",
+    "ValidationIssue",
+    "ValidationResult",
+]

--- a/src/resume_core/models/approval.py
+++ b/src/resume_core/models/approval.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, Field
+
+
+class ReviewDecision(BaseModel):
+    decision: str
+    comments: str | None = None
+    reviewer: str = "user"
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class ApprovalWorkflow(BaseModel):
+    resume_id: str
+    status: str
+    history: list[ReviewDecision] = Field(default_factory=list)
+
+    def record(self, decision: ReviewDecision) -> None:
+        self.history.append(decision)
+        self.status = (
+            decision.decision if decision.decision != "changes_requested" else "changes_requested"
+        )

--- a/src/resume_core/models/job_analysis.py
+++ b/src/resume_core/models/job_analysis.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class JobRequirement(BaseModel):
+    name: str
+    importance: str = "medium"
+    keywords: list[str] = Field(default_factory=list)
+    description: str | None = None
+
+
+class JobContext(BaseModel):
+    role: str | None = None
+    company: str | None = None
+    seniority: str | None = None
+    raw_text: str
+
+
+class JobAnalysis(BaseModel):
+    summary: str
+    requirements: list[JobRequirement]
+    keywords: list[str]
+    context: JobContext

--- a/src/resume_core/models/matching.py
+++ b/src/resume_core/models/matching.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SkillMatch(BaseModel):
+    requirement: str
+    matched_items: list[str] = Field(default_factory=list)
+    match_score: float = 0.0
+
+
+class GapAnalysis(BaseModel):
+    requirement: str
+    missing_skills: list[str] = Field(default_factory=list)
+
+
+class MatchingResult(BaseModel):
+    overall_score: float
+    matched_skills: list[SkillMatch] = Field(default_factory=list)
+    gaps: list[GapAnalysis] = Field(default_factory=list)
+    recommendations: list[str] = Field(default_factory=list)

--- a/src/resume_core/models/profile.py
+++ b/src/resume_core/models/profile.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ContactInfo(BaseModel):
+    name: str = ""
+    email: str = ""
+    phone: str = ""
+    location: str = ""
+
+
+class ExperienceAchievement(BaseModel):
+    description: str
+    metrics: str | None = None
+
+
+class WorkExperience(BaseModel):
+    role: str
+    company: str
+    start_date: str
+    end_date: str | None = None
+    achievements: list[ExperienceAchievement] = Field(default_factory=list)
+    skills: list[str] = Field(default_factory=list)
+
+
+class EducationEntry(BaseModel):
+    degree: str
+    institution: str
+    start_date: str | None = None
+    end_date: str | None = None
+    honors: str | None = None
+
+
+class SkillEntry(BaseModel):
+    name: str
+    level: str | None = None
+
+
+class ProjectEntry(BaseModel):
+    name: str
+    description: str
+    skills: list[str] = Field(default_factory=list)
+    outcomes: str | None = None
+
+
+class CertificationEntry(BaseModel):
+    name: str
+    authority: str | None = None
+    year: int | None = None
+
+
+class LanguageEntry(BaseModel):
+    name: str
+    proficiency: str | None = None
+
+
+class UserProfile(BaseModel):
+    contact: ContactInfo = Field(default_factory=ContactInfo)
+    summary: str = ""
+    experience: list[WorkExperience] = Field(default_factory=list)
+    education: list[EducationEntry] = Field(default_factory=list)
+    skills: list[SkillEntry] = Field(default_factory=list)
+    projects: list[ProjectEntry] = Field(default_factory=list)
+    certifications: list[CertificationEntry] = Field(default_factory=list)
+    languages: list[LanguageEntry] = Field(default_factory=list)
+
+    def merge_overrides(self, overrides: dict[str, Any] | None) -> "UserProfile":
+        if not overrides:
+            return self
+        updated = self.model_dump()
+        for key, value in overrides.items():
+            if key in {
+                "experience",
+                "education",
+                "skills",
+                "projects",
+                "certifications",
+                "languages",
+            }:
+                updated[key] = value
+            else:
+                updated[key] = value
+        return UserProfile.model_validate(updated)
+
+    @classmethod
+    def empty(cls) -> "UserProfile":
+        return cls()

--- a/src/resume_core/models/resume.py
+++ b/src/resume_core/models/resume.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ResumeSection(BaseModel):
+    title: str
+    content: str
+
+
+class ContentOptimization(BaseModel):
+    focus_keywords: list[str] = Field(default_factory=list)
+    readability_score: float = 0.0
+    action_verbs_used: list[str] = Field(default_factory=list)
+
+
+class TailoredResume(BaseModel):
+    resume_id: str
+    job_title: str
+    summary: str
+    sections: list[ResumeSection]
+    markdown: str
+    created_at: datetime
+    optimization: ContentOptimization = Field(default_factory=ContentOptimization)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def to_download_payload(self) -> dict[str, Any]:
+        return {
+            "resume_id": self.resume_id,
+            "content_type": "text/markdown",
+            "content": self.markdown,
+        }

--- a/src/resume_core/models/validation.py
+++ b/src/resume_core/models/validation.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ValidationIssue(BaseModel):
+    code: str
+    field: str
+    message: str
+    severity: str = "warning"
+
+
+class ValidationResult(BaseModel):
+    passed: bool
+    issues: list[ValidationIssue] = Field(default_factory=list)
+    score: float = 0.0

--- a/src/resume_core/services/__init__.py
+++ b/src/resume_core/services/__init__.py
@@ -1,3 +1,12 @@
 from resume_core.services.analysis import AnalysisService
+from resume_core.services.profile_service import ProfileService
+from resume_core.services.resume_service import ResumeTailoringService, TailoringResult
+from resume_core.services.storage_service import StorageService
 
-__all__ = ["AnalysisService"]
+__all__ = [
+    "AnalysisService",
+    "ProfileService",
+    "ResumeTailoringService",
+    "TailoringResult",
+    "StorageService",
+]

--- a/src/resume_core/services/profile_service.py
+++ b/src/resume_core/services/profile_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from resume_core.models.profile import UserProfile
+from resume_core.services.storage_service import StorageService
+
+
+class ProfileService:
+    def __init__(
+        self,
+        storage_service: StorageService | None = None,
+        *,
+        base_path: Path | str | None = None,
+    ) -> None:
+        self.storage = storage_service or StorageService(base_path=base_path)
+
+    def load_profile(self) -> UserProfile:
+        data = self.storage.load_profile()
+        if not data:
+            return UserProfile.empty()
+        return UserProfile.model_validate(data)
+
+    def save_profile(self, profile: UserProfile | dict[str, Any]) -> UserProfile:
+        if not isinstance(profile, UserProfile):
+            profile = UserProfile.model_validate(profile)
+        self.storage.save_profile(profile.model_dump())
+        return profile
+
+    def update_profile(self, payload: dict[str, Any]) -> UserProfile:
+        current = self.load_profile()
+        updated = current.merge_overrides(payload)
+        self.storage.save_profile(updated.model_dump())
+        return updated

--- a/src/resume_core/services/resume_service.py
+++ b/src/resume_core/services/resume_service.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from resume_core.agents.human_interface_agent import HumanInterfaceAgent
+from resume_core.agents.job_analysis_agent import JobAnalysisAgent
+from resume_core.agents.profile_matching_agent import ProfileMatchingAgent
+from resume_core.agents.resume_generation_agent import ResumeGenerationAgent
+from resume_core.agents.validation_agent import ValidationAgent
+from resume_core.models.approval import ApprovalWorkflow, ReviewDecision
+from resume_core.models.job_analysis import JobAnalysis
+from resume_core.models.matching import MatchingResult
+from resume_core.models.profile import UserProfile
+from resume_core.models.resume import TailoredResume
+from resume_core.models.validation import ValidationResult
+from resume_core.services.profile_service import ProfileService
+from resume_core.services.storage_service import StorageService
+from resume_core.utils.validation import ensure_decision_value
+
+
+class TailoringResult(BaseModel):
+    resume: TailoredResume
+    analysis: JobAnalysis
+    matching: MatchingResult
+    validation: ValidationResult
+    recommendation: ReviewDecision
+    status: str = Field(default="draft")
+
+
+class ResumeTailoringService:
+    def __init__(
+        self,
+        profile_service: ProfileService | None = None,
+        storage_service: StorageService | None = None,
+        *,
+        base_path: str | None = None,
+    ) -> None:
+        if storage_service is not None:
+            self.storage = storage_service
+        elif profile_service is not None:
+            self.storage = profile_service.storage
+        else:
+            self.storage = StorageService(base_path=base_path)
+
+        self.profile_service = profile_service or ProfileService(storage_service=self.storage)
+        self.job_analysis_agent = JobAnalysisAgent()
+        self.profile_matching_agent = ProfileMatchingAgent()
+        self.resume_generation_agent = ResumeGenerationAgent()
+        self.validation_agent = ValidationAgent()
+        self.human_interface_agent = HumanInterfaceAgent()
+
+    async def tailor_resume(
+        self,
+        *,
+        job_posting: str,
+        profile_overrides: dict[str, Any] | None = None,
+    ) -> TailoringResult:
+        profile: UserProfile = self.profile_service.load_profile()
+        if profile_overrides:
+            profile = profile.merge_overrides(profile_overrides)
+            self.profile_service.save_profile(profile)
+
+        analysis = await self.job_analysis_agent.analyze(job_posting=job_posting)
+        matching = await self.profile_matching_agent.match(profile=profile, analysis=analysis)
+        resume = await self.resume_generation_agent.generate(
+            profile=profile,
+            analysis=analysis,
+            matching=matching,
+        )
+        validation = await self.validation_agent.evaluate(
+            resume=resume,
+            matching=matching,
+            analysis=analysis,
+        )
+        recommendation = await self.human_interface_agent.review(
+            resume=resume,
+            validation=validation,
+        )
+        record = {
+            "resume": resume.model_dump(),
+            "analysis": analysis.model_dump(),
+            "matching": matching.model_dump(),
+            "validation": validation.model_dump(),
+            "recommendation": recommendation.model_dump(),
+            "status": "draft",
+        }
+        self.storage.save_resume_snapshot(resume.resume_id, record)
+        return TailoringResult(
+            resume=resume,
+            analysis=analysis,
+            matching=matching,
+            validation=validation,
+            recommendation=recommendation,
+            status="draft",
+        )
+
+    async def approve_resume(
+        self,
+        *,
+        resume_id: str,
+        decision: str,
+        comments: str | None = None,
+    ) -> ApprovalWorkflow:
+        normalized_decision = ensure_decision_value(decision)
+        record = self.storage.load_resume(resume_id)
+        workflow = ApprovalWorkflow(
+            resume_id=resume_id,
+            status=record.get("status", "draft"),
+            history=[ReviewDecision.model_validate(item) for item in record.get("history", [])],
+        )
+        review = ReviewDecision(decision=normalized_decision, comments=comments)
+        workflow.record(review)
+        record.update(
+            {
+                "status": workflow.status,
+                "history": [item.model_dump() for item in workflow.history],
+                "decision": review.model_dump(),
+            }
+        )
+        self.storage.update_resume(resume_id, record)
+        return workflow
+
+    def load_resume(self, resume_id: str) -> TailoringResult:
+        record = self.storage.load_resume(resume_id)
+        return TailoringResult(
+            resume=TailoredResume.model_validate(record["resume"]),
+            analysis=JobAnalysis.model_validate(record["analysis"]),
+            matching=MatchingResult.model_validate(record["matching"]),
+            validation=ValidationResult.model_validate(record["validation"]),
+            recommendation=ReviewDecision.model_validate(record["recommendation"]),
+            status=record.get("status", "draft"),
+        )
+
+    def list_history(self) -> list[dict[str, Any]]:
+        return self.storage.list_resume_metadata()
+
+    def download_resume(self, resume_id: str) -> dict[str, Any]:
+        resume = self.load_resume(resume_id).resume
+        return resume.to_download_payload()

--- a/src/resume_core/services/storage_service.py
+++ b/src/resume_core/services/storage_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+class StorageService:
+    def __init__(self, base_path: Path | str | None = None) -> None:
+        resolved_base = Path(
+            base_path or os.getenv("RESUME_ASSISTANT_DATA_DIR") or Path.home() / ".resume_assistant"
+        )
+        self.base_path = resolved_base
+        self.resumes_path = self.base_path / "resumes"
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.resumes_path.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def profile_path(self) -> Path:
+        return self.base_path / "profile.json"
+
+    def load_profile(self) -> dict[str, Any]:
+        if not self.profile_path.exists():
+            return {}
+        return json.loads(self.profile_path.read_text())
+
+    def save_profile(self, data: dict[str, Any]) -> None:
+        self.profile_path.write_text(json.dumps(data, indent=2, sort_keys=True))
+
+    def save_resume_snapshot(self, resume_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        record = self.load_resume(resume_id) if self.has_resume(resume_id) else {}
+        history = record.get("history", [])
+        payload.setdefault("history", history)
+        self._write_resume(resume_id, payload)
+        return payload
+
+    def has_resume(self, resume_id: str) -> bool:
+        return (self.resumes_path / f"{resume_id}.json").exists()
+
+    def load_resume(self, resume_id: str) -> dict[str, Any]:
+        path = self.resumes_path / f"{resume_id}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"Resume {resume_id} not found")
+        return json.loads(path.read_text())
+
+    def update_resume(self, resume_id: str, update: dict[str, Any]) -> dict[str, Any]:
+        record = self.load_resume(resume_id)
+        record.update(update)
+        self._write_resume(resume_id, record)
+        return record
+
+    def list_resume_metadata(self) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        for path in sorted(self.resumes_path.glob("*.json")):
+            data = json.loads(path.read_text())
+            resume = data.get("resume", {})
+            items.append(
+                {
+                    "resume_id": resume.get("resume_id", path.stem),
+                    "status": data.get("status", "draft"),
+                    "job_title": resume.get("job_title"),
+                    "created_at": resume.get("created_at"),
+                }
+            )
+        return items
+
+    def _write_resume(self, resume_id: str, payload: dict[str, Any]) -> None:
+        self.resumes_path.mkdir(parents=True, exist_ok=True)
+        path = self.resumes_path / f"{resume_id}.json"
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=self._json_default))
+
+    @staticmethod
+    def _json_default(value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return value

--- a/src/resume_core/utils/__init__.py
+++ b/src/resume_core/utils/__init__.py
@@ -1,0 +1,5 @@
+from resume_core.utils.errors import ResumeAssistantError
+from resume_core.utils.retry import async_retry
+from resume_core.utils.validation import ensure_decision_value
+
+__all__ = ["ResumeAssistantError", "async_retry", "ensure_decision_value"]

--- a/src/resume_core/utils/errors.py
+++ b/src/resume_core/utils/errors.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class ResumeAssistantError(Exception):
+    """Base exception for resume assistant domain."""
+
+
+class ValidationFailure(ResumeAssistantError):
+    """Raised when validation rules cannot be satisfied."""
+
+
+class NotFoundError(ResumeAssistantError):
+    """Raised when requested data cannot be located."""

--- a/src/resume_core/utils/retry.py
+++ b/src/resume_core/utils/retry.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+async def async_retry(
+    func: Callable[..., Awaitable[T]],
+    *args,
+    retries: int = 2,
+    delay: float = 0.25,
+    backoff: float = 2.0,
+    exceptions: tuple[type[Exception], ...] = (Exception,),
+    **kwargs,
+) -> T:
+    attempt = 0
+    wait_time = delay
+    while True:
+        try:
+            return await func(*args, **kwargs)
+        except exceptions:
+            attempt += 1
+            if attempt > retries:
+                raise
+            await asyncio.sleep(wait_time)
+            wait_time *= backoff

--- a/src/resume_core/utils/validation.py
+++ b/src/resume_core/utils/validation.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Final
+
+VALID_DECISIONS: Final[dict[str, str]] = {
+    "approve": "approved",
+    "approved": "approved",
+    "accept": "approved",
+    "changes_requested": "changes_requested",
+    "request_changes": "changes_requested",
+    "revise": "changes_requested",
+    "reject": "rejected",
+    "rejected": "rejected",
+}
+
+
+def ensure_decision_value(decision: str) -> str:
+    normalized = decision.strip().lower()
+    if normalized not in VALID_DECISIONS:
+        raise ValueError(f"Unsupported decision value: {decision}")
+    return VALID_DECISIONS[normalized]

--- a/tests/contract/test_approval.py
+++ b/tests/contract/test_approval.py
@@ -1,0 +1,26 @@
+import pytest
+from httpx import AsyncClient
+
+JOB_POSTING = """
+Principal Engineer needed to lead architecture and mentor teams. Requirements include strong communication, experience with
+FastAPI services, background in DevOps, and ability to write clear technical documentation.
+"""
+
+
+@pytest.mark.asyncio
+async def test_resume_approval_contract(async_client: AsyncClient) -> None:
+    draft = await async_client.post(
+        "/api/v1/resumes/tailor",
+        json={"job_posting": JOB_POSTING},
+    )
+    resume_id = draft.json()["resume_id"]
+
+    response = await async_client.post(
+        f"/api/v1/resumes/{resume_id}/approve",
+        json={"decision": "approve", "comments": "Looks great"},
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result["status"] == "approved"
+    assert result["resume_id"] == resume_id
+    assert result["decision"]["decision"] == "approved"

--- a/tests/contract/test_download.py
+++ b/tests/contract/test_download.py
@@ -1,0 +1,26 @@
+import pytest
+from httpx import AsyncClient
+
+JOB_POSTING = """
+Site Reliability Engineer role focusing on observability, automation, and Python tooling.
+"""
+
+
+@pytest.mark.asyncio
+async def test_resume_download_contract(async_client: AsyncClient) -> None:
+    draft = await async_client.post(
+        "/api/v1/resumes/tailor",
+        json={"job_posting": JOB_POSTING},
+    )
+    resume_id = draft.json()["resume_id"]
+    await async_client.post(
+        f"/api/v1/resumes/{resume_id}/approve",
+        json={"decision": "approve"},
+    )
+
+    response = await async_client.get(f"/api/v1/resumes/{resume_id}/download")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["resume_id"] == resume_id
+    assert payload["content_type"] == "text/markdown"
+    assert payload["content"].startswith("# ")

--- a/tests/contract/test_health.py
+++ b/tests/contract/test_health.py
@@ -1,0 +1,9 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_contract_health_endpoint(async_client: AsyncClient) -> None:
+    response = await async_client.get("/api/v1/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/contract/test_history.py
+++ b/tests/contract/test_history.py
@@ -1,0 +1,21 @@
+import pytest
+from httpx import AsyncClient
+
+JOB_POSTING = """
+Security Engineer role focusing on threat modeling and automation. Requires Python, cloud security, and collaboration skills.
+"""
+
+
+@pytest.mark.asyncio
+async def test_resume_history_contract(async_client: AsyncClient) -> None:
+    await async_client.post(
+        "/api/v1/resumes/tailor",
+        json={"job_posting": JOB_POSTING},
+    )
+
+    response = await async_client.get("/api/v1/resumes/history")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "items" in payload
+    assert payload["items"]
+    assert {"resume_id", "status"}.issubset(payload["items"][0].keys())

--- a/tests/contract/test_jobs.py
+++ b/tests/contract/test_jobs.py
@@ -1,0 +1,22 @@
+import pytest
+from httpx import AsyncClient
+
+JOB_POSTING = """
+We are seeking a Senior Data Scientist to lead our analytics initiatives. Responsibilities include building machine learning
+models, collaborating with engineering, and communicating insights. Requirements: 5+ years experience, proficiency in Python and
+SQL, experience with cloud platforms like AWS, strong communication skills, and ability to mentor junior scientists.
+"""
+
+
+@pytest.mark.asyncio
+async def test_job_analysis_contract(async_client: AsyncClient) -> None:
+    response = await async_client.post(
+        "/api/v1/jobs/analyze",
+        json={"job_posting": JOB_POSTING},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    analysis = payload["analysis"]
+    assert analysis["summary"]
+    assert any(req["name"].lower().startswith("python") for req in analysis["requirements"])
+    assert analysis["keywords"]

--- a/tests/contract/test_profile.py
+++ b/tests/contract/test_profile.py
@@ -1,0 +1,83 @@
+import pytest
+from httpx import AsyncClient
+
+SAMPLE_PROFILE = {
+    "contact": {
+        "name": "Ada Lovelace",
+        "email": "ada@example.com",
+        "phone": "+44 1234 567890",
+        "location": "London, UK",
+    },
+    "summary": "Innovative engineer with focus on analytics.",
+    "experience": [
+        {
+            "role": "Data Scientist",
+            "company": "Analytica",
+            "start_date": "2020-01",
+            "end_date": "2023-06",
+            "achievements": [
+                {
+                    "description": "Built ML pipeline",
+                    "metrics": "Improved conversion by 20%",
+                }
+            ],
+            "skills": ["python", "machine learning", "data visualization"],
+        }
+    ],
+    "education": [
+        {
+            "degree": "MSc Computer Science",
+            "institution": "University of Oxford",
+            "start_date": "2018-09",
+            "end_date": "2019-06",
+            "honors": "Distinction",
+        }
+    ],
+    "skills": [
+        {"name": "Python", "level": "expert"},
+        {"name": "Machine Learning", "level": "advanced"},
+    ],
+    "projects": [
+        {
+            "name": "Resume AI",
+            "description": "Built resume tailoring assistant",
+            "skills": ["python", "fastapi"],
+        }
+    ],
+    "certifications": [
+        {
+            "name": "AWS Solutions Architect",
+            "authority": "Amazon Web Services",
+            "year": 2022,
+        }
+    ],
+    "languages": [
+        {"name": "English", "proficiency": "native"},
+        {"name": "French", "proficiency": "intermediate"},
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_get_profile_returns_default(async_client: AsyncClient) -> None:
+    response = await async_client.get("/api/v1/profile")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["profile"]["contact"]["name"] == ""
+    assert payload["profile"]["experience"] == []
+    assert payload["profile"]["skills"] == []
+
+
+@pytest.mark.asyncio
+async def test_put_profile_persists_changes(async_client: AsyncClient) -> None:
+    response = await async_client.put("/api/v1/profile", json=SAMPLE_PROFILE)
+    assert response.status_code == 200
+    saved = response.json()["profile"]
+    assert saved["contact"]["name"] == SAMPLE_PROFILE["contact"]["name"]
+    assert len(saved["experience"]) == 1
+
+    response_get = await async_client.get("/api/v1/profile")
+    assert response_get.status_code == 200
+    profile = response_get.json()["profile"]
+    assert profile["contact"]["email"] == SAMPLE_PROFILE["contact"]["email"]
+    assert profile["skills"][0]["name"].lower() == "python"

--- a/tests/contract/test_resumes.py
+++ b/tests/contract/test_resumes.py
@@ -1,0 +1,22 @@
+import pytest
+from httpx import AsyncClient
+
+JOB_POSTING = """
+Join our platform team as a Backend Engineer. Responsibilities include designing REST APIs, collaborating with product teams, and
+optimizing services. Key requirements: expertise with FastAPI, experience deploying to cloud (AWS or Azure), strong Python coding
+skills, familiarity with CI/CD, and ability to document solutions clearly.
+"""
+
+
+@pytest.mark.asyncio
+async def test_resume_tailoring_contract(async_client: AsyncClient) -> None:
+    response = await async_client.post(
+        "/api/v1/resumes/tailor",
+        json={"job_posting": JOB_POSTING},
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["status"] == "draft"
+    assert payload["resume"]["markdown"].startswith("# ")
+    assert payload["matching"]["overall_score"] >= 0
+    assert payload["analysis"]["summary"]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from resume_core.models.profile import (
+    ContactInfo,
+    EducationEntry,
+    ExperienceAchievement,
+    SkillEntry,
+    UserProfile,
+    WorkExperience,
+)
+
+SAMPLE_JOB_POSTING = "Senior Backend Engineer needed to build FastAPI services, manage AWS infrastructure, and mentor developers."
+
+
+def build_sample_profile() -> UserProfile:
+    return UserProfile(
+        contact=ContactInfo(
+            name="Jordan Smith",
+            email="jordan@example.com",
+            phone="555-0100",
+            location="Remote",
+        ),
+        summary="Backend engineer with strong FastAPI and AWS experience.",
+        experience=[
+            WorkExperience(
+                role="Senior Backend Engineer",
+                company="ScaleUp",
+                start_date="2019-01",
+                end_date="2023-12",
+                achievements=[
+                    ExperienceAchievement(
+                        description="Led migration to FastAPI microservices",
+                        metrics="Cut latency by 40%",
+                    )
+                ],
+                skills=["python", "fastapi", "aws", "mentoring"],
+            )
+        ],
+        education=[
+            EducationEntry(
+                degree="BSc Computer Science",
+                institution="Tech University",
+                start_date="2012-09",
+                end_date="2016-06",
+            )
+        ],
+        skills=[
+            SkillEntry(name="Python", level="expert"),
+            SkillEntry(name="FastAPI", level="advanced"),
+            SkillEntry(name="AWS", level="advanced"),
+        ],
+    )

--- a/tests/integration/test_agent_chain.py
+++ b/tests/integration/test_agent_chain.py
@@ -1,0 +1,20 @@
+import pytest
+
+from resume_core.services.profile_service import ProfileService
+from resume_core.services.resume_service import ResumeTailoringService
+from tests.factories import SAMPLE_JOB_POSTING, build_sample_profile
+
+
+@pytest.mark.asyncio
+async def test_agent_chain_workflow(tmp_path) -> None:
+    profile_service = ProfileService(base_path=tmp_path)
+    profile_service.save_profile(build_sample_profile())
+    resume_service = ResumeTailoringService(profile_service=profile_service)
+
+    result = await resume_service.tailor_resume(job_posting=SAMPLE_JOB_POSTING)
+
+    assert result.resume.resume_id
+    assert result.analysis.requirements
+    assert result.matching.overall_score > 0
+    assert result.validation.passed is True
+    assert result.recommendation.decision in {"approved", "changes_requested"}

--- a/tests/integration/test_approval_workflow.py
+++ b/tests/integration/test_approval_workflow.py
@@ -1,0 +1,23 @@
+import pytest
+
+from resume_core.services.profile_service import ProfileService
+from resume_core.services.resume_service import ResumeTailoringService
+from tests.factories import SAMPLE_JOB_POSTING, build_sample_profile
+
+
+@pytest.mark.asyncio
+async def test_approval_workflow_records_decisions(tmp_path) -> None:
+    profile_service = ProfileService(base_path=tmp_path)
+    profile_service.save_profile(build_sample_profile())
+    resume_service = ResumeTailoringService(profile_service=profile_service)
+    result = await resume_service.tailor_resume(job_posting=SAMPLE_JOB_POSTING)
+
+    approval = await resume_service.approve_resume(
+        resume_id=result.resume.resume_id,
+        decision="approve",
+        comments="Ready to submit",
+    )
+
+    assert approval.status == "approved"
+    assert approval.history[-1].decision == "approved"
+    assert approval.history[-1].comments == "Ready to submit"

--- a/tests/integration/test_job_analysis.py
+++ b/tests/integration/test_job_analysis.py
@@ -1,0 +1,13 @@
+import pytest
+
+from resume_core.agents.job_analysis_agent import JobAnalysisAgent
+from tests.factories import SAMPLE_JOB_POSTING
+
+
+@pytest.mark.asyncio
+async def test_job_analysis_agent_extracts_requirements() -> None:
+    agent = JobAnalysisAgent()
+    analysis = await agent.analyze(job_posting=SAMPLE_JOB_POSTING)
+    assert analysis.summary
+    assert analysis.requirements
+    assert any("fastapi" in keyword for keyword in analysis.keywords)

--- a/tests/integration/test_profile_matching.py
+++ b/tests/integration/test_profile_matching.py
@@ -1,0 +1,17 @@
+import pytest
+
+from resume_core.agents.job_analysis_agent import JobAnalysisAgent
+from resume_core.agents.profile_matching_agent import ProfileMatchingAgent
+from tests.factories import SAMPLE_JOB_POSTING, build_sample_profile
+
+
+@pytest.mark.asyncio
+async def test_profile_matching_scores_skills() -> None:
+    analysis = await JobAnalysisAgent().analyze(job_posting=SAMPLE_JOB_POSTING)
+    matching = await ProfileMatchingAgent().match(
+        profile=build_sample_profile(),
+        analysis=analysis,
+    )
+    assert matching.overall_score > 0.5
+    assert matching.matched_skills
+    assert matching.recommendations

--- a/tests/integration/test_resume_generation.py
+++ b/tests/integration/test_resume_generation.py
@@ -1,0 +1,22 @@
+import pytest
+
+from resume_core.agents.job_analysis_agent import JobAnalysisAgent
+from resume_core.agents.profile_matching_agent import ProfileMatchingAgent
+from resume_core.agents.resume_generation_agent import ResumeGenerationAgent
+from resume_core.models.resume import TailoredResume
+from tests.factories import SAMPLE_JOB_POSTING, build_sample_profile
+
+
+@pytest.mark.asyncio
+async def test_resume_generation_produces_markdown() -> None:
+    profile = build_sample_profile()
+    analysis = await JobAnalysisAgent().analyze(job_posting=SAMPLE_JOB_POSTING)
+    matching = await ProfileMatchingAgent().match(profile=profile, analysis=analysis)
+    resume = await ResumeGenerationAgent().generate(
+        profile=profile,
+        analysis=analysis,
+        matching=matching,
+    )
+    assert isinstance(resume, TailoredResume)
+    assert resume.markdown.startswith("# ")
+    assert "FastAPI" in resume.markdown

--- a/tests/integration/test_validation.py
+++ b/tests/integration/test_validation.py
@@ -1,0 +1,24 @@
+import pytest
+
+from resume_core.agents.job_analysis_agent import JobAnalysisAgent
+from resume_core.agents.profile_matching_agent import ProfileMatchingAgent
+from resume_core.agents.resume_generation_agent import ResumeGenerationAgent
+from resume_core.agents.validation_agent import ValidationAgent
+from tests.factories import SAMPLE_JOB_POSTING, build_sample_profile
+
+
+@pytest.mark.asyncio
+async def test_validation_agent_detects_gaps() -> None:
+    profile = build_sample_profile()
+    analysis = await JobAnalysisAgent().analyze(job_posting=SAMPLE_JOB_POSTING)
+    matching = await ProfileMatchingAgent().match(profile=profile, analysis=analysis)
+    resume = await ResumeGenerationAgent().generate(
+        profile=profile, analysis=analysis, matching=matching
+    )
+    validation = await ValidationAgent().evaluate(
+        resume=resume, matching=matching, analysis=analysis
+    )
+
+    assert validation.passed
+    assert validation.issues == []
+    assert validation.score >= 0.7


### PR DESCRIPTION
## Summary
- implement a pydanticAI-driven agent suite for job analysis, profile matching, resume generation, validation, and human review orchestration
- add resume data models, storage utilities, and service orchestration with FastAPI endpoints for profile, job analysis, resume tailoring, approval, download, and history
- create contract and integration tests that exercise the end-to-end tailoring workflow and supporting APIs
- ensure approval workflow timestamps are stored as timezone-aware UTC values to avoid warnings during validation

## Testing
- uv run pytest
- curl http://localhost:8000/api/v1/health
- curl -X PUT http://localhost:8000/api/v1/profile
- curl -X POST http://localhost:8000/api/v1/jobs/analyze
- curl -X POST http://localhost:8000/api/v1/resumes/tailor
- curl -X POST http://localhost:8000/api/v1/resumes/{id}/approve
- curl http://localhost:8000/api/v1/resumes/{id}/download

------
https://chatgpt.com/codex/tasks/task_e_68cb4df7964883339a384842b23be866