### PR TITLE
Enforce approval gating and reuse job analyses

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from app.core.settings import SettingsDep
+from resume_core.services import ProfileStore, ResumeTailoringService
+
+
+def _default_data_dir() -> Path:
+    env_dir = os.environ.get("RESUME_ASSISTANT_DATA_DIR")
+    if env_dir:
+        return Path(env_dir)
+    return Path.home() / ".resume-assistant"
+
+
+@lru_cache
+def _build_service(data_dir: str | None) -> ResumeTailoringService:
+    base_path = Path(data_dir) if data_dir else _default_data_dir()
+    store = ProfileStore(base_path=base_path)
+    return ResumeTailoringService(profile_store=store)
+
+
+def get_tailoring_service(settings: SettingsDep) -> ResumeTailoringService:
+    return _build_service(settings.DATA_DIR)
+

--- a/app/api/v1/routers/__init__.py
+++ b/app/api/v1/routers/__init__.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from . import health, jobs, profile, resumes
+
+router = APIRouter()
+
+router.include_router(health.router)
+router.include_router(profile.router)
+router.include_router(jobs.router)
+router.include_router(resumes.router)
+
+__all__ = ["router"]
+

--- a/app/api/v1/routers/health.py
+++ b/app/api/v1/routers/health.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from fastapi import APIRouter
 
 router = APIRouter(tags=["health"])
@@ -5,4 +7,9 @@ router = APIRouter(tags=["health"])
 
 @router.get("/health")
 async def health_check() -> dict[str, str]:
-    return {"status": "ok"}
+    """Simple liveness probe used by the quickstart manual tests."""
+
+    return {
+        "status": "healthy",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/app/api/v1/routers/jobs.py
+++ b/app/api/v1/routers/jobs.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.deps import get_tailoring_service
+from resume_core.models import JobAnalysis
+from resume_core.services import ResumeTailoringService
+
+
+class JobAnalysisRequest(BaseModel):
+    job_description: str = Field(..., description="Raw job posting text")
+
+
+router = APIRouter(tags=["jobs"])
+
+
+@router.post("/jobs/analyze", response_model=JobAnalysis)
+async def analyze_job(
+    request: JobAnalysisRequest,
+    service: ResumeTailoringService = Depends(get_tailoring_service),
+) -> JobAnalysis:
+    description = request.job_description.strip()
+    if not description:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Job description is required")
+    return await service.analyze_job(description)
+

--- a/app/api/v1/routers/profile.py
+++ b/app/api/v1/routers/profile.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.deps import get_tailoring_service
+from resume_core.models import UserProfile
+from resume_core.services import ResumeTailoringService
+
+router = APIRouter(tags=["profile"])
+
+
+@router.get("/profile", response_model=UserProfile)
+async def get_profile(service: ResumeTailoringService = Depends(get_tailoring_service)) -> UserProfile:
+    profile = service.profile_store.get_profile()
+    if profile is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Profile not found")
+    return profile
+
+
+@router.put("/profile", response_model=UserProfile)
+async def update_profile(
+    profile: UserProfile,
+    service: ResumeTailoringService = Depends(get_tailoring_service),
+) -> UserProfile:
+    return service.profile_store.save_profile(profile)
+

--- a/app/api/v1/routers/resumes.py
+++ b/app/api/v1/routers/resumes.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+
+from app.api.deps import get_tailoring_service
+from resume_core.models import ApprovalResult, ReviewDecision, TailoringResult
+from resume_core.services import (
+    JobAnalysisNotFoundError,
+    ProfileNotFoundError,
+    ResumeNotApprovedError,
+    ResumeNotFoundError,
+    ResumeTailoringService,
+    TailoringPreferences,
+    UnsupportedFormatError,
+    validate_preferences,
+)
+
+
+class TailorResumeRequest(BaseModel):
+    job_description: str = Field(..., min_length=1)
+    job_analysis_id: UUID | None = Field(default=None, description="Optional existing analysis ID")
+    preferences: dict[str, Any] | None = None
+
+
+router = APIRouter(tags=["resumes"])
+
+
+@router.post("/resumes/tailor", response_model=TailoringResult)
+async def tailor_resume(
+    request: TailorResumeRequest,
+    service: ResumeTailoringService = Depends(get_tailoring_service),
+) -> TailoringResult:
+    try:
+        preferences: TailoringPreferences = validate_preferences(request.preferences)
+        return await service.tailor_resume(
+            job_description=request.job_description,
+            job_analysis_id=request.job_analysis_id,
+            preferences=preferences,
+        )
+    except ProfileNotFoundError as exc:  # pragma: no cover - handled by API tests
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except JobAnalysisNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@router.post("/resumes/{resume_id}/approve", response_model=ApprovalResult)
+async def approve_resume(
+    resume_id: UUID,
+    decision: ReviewDecision,
+    service: ResumeTailoringService = Depends(get_tailoring_service),
+) -> ApprovalResult:
+    try:
+        return await service.approve_resume(resume_id, decision)
+    except ResumeNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+
+@router.get("/resumes/{resume_id}/download")
+async def download_resume(
+    resume_id: UUID,
+    format: str = "markdown",
+    service: ResumeTailoringService = Depends(get_tailoring_service),
+) -> Response:
+    try:
+        content = service.download_resume(resume_id, format)
+    except ResumeNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except ResumeNotApprovedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    except UnsupportedFormatError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    media_type = "text/markdown" if format == "markdown" else "application/octet-stream"
+    return Response(content=content, media_type=media_type)
+
+
+@router.get("/resumes/history")
+async def get_history(
+    limit: int = 10,
+    offset: int = 0,
+    service: ResumeTailoringService = Depends(get_tailoring_service),
+) -> dict[str, Any]:
+    items, total = service.get_history(limit=limit, offset=offset)
+    return {
+        "resumes": [item.model_dump(mode="json") for item in items],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     ENV: str = "dev"
     MODEL_NAME: str = "gpt-4o"
     OPENAI_API_KEY: str | None = None
+    DATA_DIR: str | None = None
 
     APP_NAME: str = "Resume Assistant API"
     VERSION: str = "0.1.0"

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1.routers import health
+from app.api.v1.routers import router as api_router
 from app.core.errors import install_error_handlers
 from app.core.settings import get_settings
 
@@ -23,7 +23,11 @@ def create_application() -> FastAPI:
         allow_headers=["*"],
     )
 
-    app.include_router(health.router, prefix="/api/v1")
+    # Expose both versioned and unversioned routes so the quickstart scripts that
+    # target the root paths continue to function while tests exercise the
+    # versioned namespace.
+    app.include_router(api_router)
+    app.include_router(api_router, prefix="/api/v1")
 
     install_error_handlers(app)
 

--- a/specs/001-resume-tailoring-feature/contracts/api_spec.yaml
+++ b/specs/001-resume-tailoring-feature/contracts/api_spec.yaml
@@ -481,6 +481,9 @@ components:
     JobAnalysis:
       type: object
       properties:
+        analysis_id:
+          type: string
+          format: uuid
         company_name:
           type: string
         job_title:
@@ -520,6 +523,7 @@ components:
           items:
             type: string
       required:
+        - analysis_id
         - company_name
         - job_title
         - location

--- a/src/resume_core/agents/__init__.py
+++ b/src/resume_core/agents/__init__.py
@@ -1,3 +1,19 @@
 from resume_core.agents.base_agent import Agent
+from resume_core.agents.tailoring import (
+    HumanInterfaceAgent,
+    JobAnalysisAgent,
+    ProfileMatchingAgent,
+    ResumeGenerationAgent,
+    TailoringAgents,
+    ValidationAgent,
+)
 
-__all__ = ["Agent"]
+__all__ = [
+    "Agent",
+    "JobAnalysisAgent",
+    "ProfileMatchingAgent",
+    "ResumeGenerationAgent",
+    "ValidationAgent",
+    "HumanInterfaceAgent",
+    "TailoringAgents",
+]

--- a/src/resume_core/agents/tailoring.py
+++ b/src/resume_core/agents/tailoring.py
@@ -1,0 +1,682 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from pydantic import TypeAdapter
+from pydantic_ai import Agent as LlmAgent
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+
+from resume_core.models.job import JobAnalysis, JobRequirement, ResponsibilityLevel
+from resume_core.models.matching import ExperienceMatch, MatchingResult, SkillMatch
+from resume_core.models.profile import Skill, SkillCategory, UserProfile
+from resume_core.models.resume import (
+    ApprovalWorkflow,
+    ResumeOptimization,
+    TailoredResume,
+    ValidationResult,
+)
+
+
+KNOWN_SKILLS = {
+    "python": "Python",
+    "fastapi": "FastAPI",
+    "django": "Django",
+    "flask": "Flask",
+    "postgresql": "PostgreSQL",
+    "sql": "SQL",
+    "aws": "AWS",
+    "docker": "Docker",
+    "kubernetes": "Kubernetes",
+    "leadership": "Leadership",
+    "leading": "Leadership",
+}
+
+
+def _json_response(payload: Any) -> ModelResponse:
+    def default_encoder(value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return value
+
+    return ModelResponse(parts=[TextPart(content=json.dumps(payload, default=default_encoder))])
+
+
+def _latest_prompt(messages: list) -> str:
+    # The `FunctionModel` passes ModelMessage instances. The last entry contains the
+    # user prompt as the first part.
+    return messages[-1].parts[0].content if messages and messages[-1].parts else ""
+
+
+class JobAnalysisAgent:
+    def __init__(self) -> None:
+        def handler(messages, agent_info):  # type: ignore[override]
+            description = _latest_prompt(messages)
+            analysis = self._build_analysis(description)
+            return _json_response(analysis.model_dump(mode="json"))
+
+        self._adapter: TypeAdapter[JobAnalysis] = TypeAdapter(JobAnalysis)
+        self._agent = LlmAgent(FunctionModel(handler), output_type=str)
+
+    async def analyze(self, job_description: str) -> JobAnalysis:
+        result = await self._agent.run(job_description)
+        data = json.loads(result.output)
+        return self._adapter.validate_python(data)
+
+    def _build_analysis(self, description: str) -> JobAnalysis:
+        lines = [line.strip() for line in description.splitlines()]
+        non_empty = [line for line in lines if line]
+
+        job_title = self._normalize_title(non_empty[0]) if non_empty else "Unknown Role"
+        company = non_empty[1] if len(non_empty) > 1 else "Unknown Company"
+
+        requirements: list[JobRequirement] = []
+        preferred: list[str] = []
+        in_preferred_section = False
+        for raw_line in lines:
+            if not raw_line:
+                in_preferred_section = False
+                continue
+            lowered = raw_line.lower()
+            if lowered.startswith("preferred qualifications"):
+                in_preferred_section = True
+                continue
+            if lowered.startswith("preferred"):
+                in_preferred_section = True
+                preferred.append(raw_line.split(":", 1)[-1].strip())
+                continue
+            if raw_line.startswith(("-", "•")):
+                batch = self._requirements_from_line(raw_line, preferred=in_preferred_section)
+                requirements.extend(batch)
+                if in_preferred_section:
+                    preferred.append(raw_line.lstrip("-• ").strip())
+                continue
+
+        if not requirements:
+            requirements.extend(self._keyword_requirements(description))
+
+        role_level = self._infer_level(job_title)
+        responsibilities = self._extract_responsibilities(description)
+        culture = "collaborative environment" if re.search(r"team|collaborative", description, re.I) else "Not specified"
+        remote_policy = "Remote friendly" if re.search(r"remote", description, re.I) else None
+
+        return JobAnalysis(
+            company_name=company,
+            job_title=job_title,
+            location=self._extract_location(description),
+            remote_policy=remote_policy,
+            requirements=requirements,
+            key_responsibilities=responsibilities,
+            company_culture=culture,
+            role_level=role_level,
+            industry="technology",
+            benefits=self._extract_benefits(description),
+            preferred_qualifications=[pref for pref in preferred if pref],
+        )
+
+    def _requirements_from_line(self, line: str, *, preferred: bool) -> list[JobRequirement]:
+        text = line.lstrip("-• ")
+        skill_names = self._extract_skill_names(text)
+        if not skill_names:
+            return [self._make_requirement(line, preferred=preferred)]
+
+        importance = self._determine_importance(text, preferred=preferred)
+        is_required = self._is_required(text, preferred=preferred)
+
+        requirements = []
+        for skill in skill_names:
+            requirements.append(
+                JobRequirement(
+                    skill=skill,
+                    importance=importance,
+                    category=self._categorize_skill(skill),
+                    is_required=is_required,
+                    context=text,
+                )
+            )
+        return requirements
+
+    def _make_requirement(self, line: str, *, preferred: bool) -> JobRequirement:
+        text = line.lstrip("-• ")
+        skill_name = self._extract_skill_name(text)
+        category = self._categorize_skill(skill_name)
+        importance = self._determine_importance(text, preferred=preferred)
+        is_required = self._is_required(text, preferred=preferred)
+        return JobRequirement(
+            skill=skill_name,
+            importance=importance,
+            category=category,
+            is_required=is_required,
+            context=text,
+        )
+
+    def _determine_importance(self, text: str, *, preferred: bool) -> int:
+        if preferred:
+            return 3
+        if re.search(r"must|required", text, re.I):
+            return 5
+        if re.search(r"nice to have|preferred", text, re.I):
+            return 3
+        return 4
+
+    def _is_required(self, text: str, *, preferred: bool) -> bool:
+        if preferred:
+            return False
+        return not re.search(r"preferred|nice to have", text, re.I)
+
+    def _normalize_title(self, line: str) -> str:
+        for separator in [" wanted", " needed", " - ", " — ", ":", "|", " with ", " role", " position"]:
+            if separator in line:
+                return line.split(separator)[0].strip()
+        return line.strip()
+
+    def _extract_skill_name(self, text: str) -> str:
+        lower = text.lower()
+        for key, value in KNOWN_SKILLS.items():
+            if re.search(rf"\b{re.escape(key)}\b", lower):
+                return value
+        cleaned = re.sub(r"[^a-zA-Z0-9 ]", "", text).strip()
+        return cleaned.split()[0].title() if cleaned else "General Skill"
+
+    def _extract_skill_names(self, text: str) -> list[str]:
+        lower = text.lower()
+        found: list[str] = []
+        for key, value in KNOWN_SKILLS.items():
+            if re.search(rf"\b{re.escape(key)}\b", lower) and value not in found:
+                found.append(value)
+        return found
+
+    def _keyword_requirements(self, description: str) -> list[JobRequirement]:
+        requirements: list[JobRequirement] = []
+        lowered = description.lower()
+        for key, value in KNOWN_SKILLS.items():
+            if re.search(rf"\b{re.escape(key)}\b", lowered):
+                requirements.append(
+                    JobRequirement(
+                        skill=value,
+                        importance=4,
+                        category=self._categorize_skill(value),
+                        is_required=True,
+                        context=f"Mentioned in description: {value}",
+                    )
+                )
+        return requirements
+
+    def _categorize_skill(self, skill: str) -> SkillCategory:
+        technical = {"Python", "FastAPI", "Django", "Flask", "PostgreSQL", "SQL", "AWS", "Docker", "Kubernetes"}
+        return SkillCategory.TECHNICAL if skill in technical else SkillCategory.SOFT
+
+    def _infer_level(self, job_title: str) -> ResponsibilityLevel:
+        lower = job_title.lower()
+        if "intern" in lower or "junior" in lower:
+            return ResponsibilityLevel.JUNIOR
+        if "senior" in lower:
+            return ResponsibilityLevel.SENIOR
+        if "lead" in lower or "principal" in lower:
+            return ResponsibilityLevel.LEAD
+        if "director" in lower or "chief" in lower:
+            return ResponsibilityLevel.EXECUTIVE
+        return ResponsibilityLevel.MID
+
+    def _extract_responsibilities(self, description: str) -> list[str]:
+        responsibilities: list[str] = []
+        for sentence in re.split(r"[.!]", description):
+            sentence = sentence.strip()
+            if not sentence:
+                continue
+            if re.search(r"build|design|lead|collaborate|deliver", sentence, re.I):
+                responsibilities.append(sentence)
+        return responsibilities[:5]
+
+    def _extract_location(self, description: str) -> str:
+        match = re.search(r"based in ([A-Za-z ,]+)", description)
+        if match:
+            return match.group(1).strip()
+        return "Not specified"
+
+    def _extract_benefits(self, description: str) -> list[str]:
+        benefits: list[str] = []
+        for line in description.splitlines():
+            if re.search(r"benefits|health|vacation", line, re.I):
+                benefits.append(line.strip())
+        return benefits
+
+
+class ProfileMatchingAgent:
+    def __init__(self) -> None:
+        def handler(messages, agent_info):  # type: ignore[override]
+            payload = json.loads(_latest_prompt(messages))
+            analysis = self._analysis_adapter.validate_python(payload["job_analysis"])
+            profile = self._profile_adapter.validate_python(payload["profile"])
+            matching = self._match_profile(analysis, profile)
+            return _json_response(matching.model_dump(mode="json"))
+
+        self._analysis_adapter: TypeAdapter[JobAnalysis] = TypeAdapter(JobAnalysis)
+        self._profile_adapter: TypeAdapter[UserProfile] = TypeAdapter(UserProfile)
+        self._adapter: TypeAdapter[MatchingResult] = TypeAdapter(MatchingResult)
+        self._agent = LlmAgent(FunctionModel(handler), output_type=str)
+
+    async def match(self, analysis: JobAnalysis, profile: UserProfile) -> MatchingResult:
+        payload = {
+            "job_analysis": analysis.model_dump(mode="json"),
+            "profile": profile.model_dump(mode="json"),
+        }
+        result = await self._agent.run(json.dumps(payload))
+        return self._adapter.validate_python(json.loads(result.output))
+
+    def _match_profile(self, analysis: JobAnalysis, profile: UserProfile) -> MatchingResult:
+        skill_map: dict[str, Skill] = {skill.name.lower(): skill for skill in profile.skills}
+        skill_matches: list[SkillMatch] = []
+        missing: list[JobRequirement] = []
+
+        for requirement in analysis.requirements:
+            key = requirement.skill.lower()
+            skill = skill_map.get(key)
+            if skill is None:
+                missing.append(requirement)
+                skill_matches.append(
+                    SkillMatch(
+                        skill_name=requirement.skill,
+                        job_importance=requirement.importance,
+                        user_proficiency=0,
+                        match_score=0.0,
+                        evidence=[],
+                    )
+                )
+                continue
+
+            evidence = self._gather_evidence(skill.name, profile)
+            match_score = round(min(1.0, skill.proficiency / 5), 2)
+            skill_matches.append(
+                SkillMatch(
+                    skill_name=skill.name,
+                    job_importance=requirement.importance,
+                    user_proficiency=skill.proficiency,
+                    match_score=match_score,
+                    evidence=evidence,
+                )
+            )
+
+        experience_matches = self._match_responsibilities(analysis, profile)
+
+        overall_score = 0.0
+        if skill_matches:
+            overall_score = round(sum(match.match_score for match in skill_matches) / len(skill_matches), 2)
+
+        strength_areas = [match.skill_name for match in skill_matches if match.match_score >= 0.6]
+        transferable_skills = [skill.name for skill in profile.skills if skill.name not in strength_areas]
+        recommendations = self._build_recommendations(missing, analysis, profile, overall_score)
+
+        return MatchingResult(
+            overall_match_score=overall_score,
+            skill_matches=skill_matches,
+            experience_matches=experience_matches,
+            missing_requirements=missing,
+            strength_areas=strength_areas,
+            transferable_skills=transferable_skills,
+            recommendations=recommendations,
+        )
+
+    def _gather_evidence(self, skill_name: str, profile: UserProfile) -> list[str]:
+        evidence: list[str] = []
+        for experience in profile.experience:
+            if any(skill_name.lower() in tech.lower() for tech in experience.technologies):
+                evidence.append(
+                    f"{experience.position} at {experience.company} using {skill_name}"
+                )
+            for achievement in experience.achievements:
+                if skill_name.lower() in achievement.lower():
+                    evidence.append(achievement)
+        return evidence[:5]
+
+    def _match_responsibilities(self, analysis: JobAnalysis, profile: UserProfile) -> list[ExperienceMatch]:
+        matches: list[ExperienceMatch] = []
+        for responsibility in analysis.key_responsibilities:
+            related: list[str] = []
+            for experience in profile.experience:
+                if any(keyword in responsibility.lower() for keyword in self._keywords(experience)):
+                    related.append(f"{experience.position} at {experience.company}")
+            score = min(1.0, len(related) / max(1, len(profile.experience))) if related else 0.0
+            matches.append(
+                ExperienceMatch(
+                    job_responsibility=responsibility,
+                    matching_experiences=related,
+                    relevance_score=round(score, 2),
+                )
+            )
+        return matches
+
+    def _keywords(self, experience: Any) -> Iterable[str]:
+        keywords = set()
+        for tech in experience.technologies:
+            keywords.add(tech.lower())
+        for achievement in experience.achievements:
+            for word in achievement.split():
+                keywords.add(word.lower().strip(",.()"))
+        return keywords
+
+    def _build_recommendations(
+        self,
+        missing: list[JobRequirement],
+        analysis: JobAnalysis,
+        profile: UserProfile,
+        overall_score: float,
+    ) -> list[str]:
+        recommendations: list[str] = []
+        for requirement in missing:
+            recommendations.append(
+                f"Provide concrete examples demonstrating {requirement.skill} experience."
+            )
+
+        if overall_score < 0.75:
+            recommendations.append("Add measurable outcomes to highlight recent impact.")
+
+        if not recommendations and analysis.key_responsibilities:
+            primary_resp = analysis.key_responsibilities[0].rstrip(".")
+            recommendations.append(
+                f"Emphasize how your achievements cover {primary_resp.lower()}."
+            )
+
+        if not recommendations and profile.experience:
+            latest_role = profile.experience[0]
+            recommendations.append(
+                f"Highlight leadership contributions from your role at {latest_role.company}."
+            )
+
+        return recommendations[:5]
+
+
+class ResumeGenerationAgent:
+    def __init__(self) -> None:
+        def handler(messages, agent_info):  # type: ignore[override]
+            payload = json.loads(_latest_prompt(messages))
+            analysis = self._analysis_adapter.validate_python(payload["job_analysis"])
+            profile = self._profile_adapter.validate_python(payload["profile"])
+            matching = self._matching_adapter.validate_python(payload["matching_result"])
+            preferences = payload.get("preferences") or {}
+            timestamp = (
+                datetime.fromisoformat(payload["timestamp"])
+                if "timestamp" in payload
+                else datetime.now(timezone.utc)
+            )
+            resume = self._generate_resume(analysis, matching, profile, preferences, timestamp)
+            return _json_response(resume.model_dump(mode="json"))
+
+        self._analysis_adapter: TypeAdapter[JobAnalysis] = TypeAdapter(JobAnalysis)
+        self._profile_adapter: TypeAdapter[UserProfile] = TypeAdapter(UserProfile)
+        self._matching_adapter: TypeAdapter[MatchingResult] = TypeAdapter(MatchingResult)
+        self._adapter: TypeAdapter[TailoredResume] = TypeAdapter(TailoredResume)
+        self._agent = LlmAgent(FunctionModel(handler), output_type=str)
+
+    async def generate(
+        self,
+        analysis: JobAnalysis,
+        matching: MatchingResult,
+        profile: UserProfile,
+        preferences: dict[str, Any],
+        timestamp: datetime,
+    ) -> TailoredResume:
+        payload = {
+            "job_analysis": analysis.model_dump(mode="json"),
+            "matching_result": matching.model_dump(mode="json"),
+            "profile": profile.model_dump(mode="json"),
+            "preferences": preferences,
+            "timestamp": timestamp.isoformat(),
+        }
+        result = await self._agent.run(json.dumps(payload))
+        return self._adapter.validate_python(json.loads(result.output))
+
+    def _generate_resume(
+        self,
+        analysis: JobAnalysis,
+        matching: MatchingResult,
+        profile: UserProfile,
+        preferences: dict[str, Any],
+        timestamp: datetime,
+    ) -> TailoredResume:
+        emphasis = [item.lower() for item in preferences.get("emphasis_areas", [])]
+        excluded_sections = {
+            str(section).replace("_", " ").strip().lower()
+            for section in preferences.get("excluded_sections", [])
+            if isinstance(section, str)
+        }
+        normalized_exclusions = set()
+        for section in excluded_sections:
+            if section in {"keymatches", "key match", "key-match"}:
+                normalized_exclusions.add("key matches")
+            else:
+                normalized_exclusions.add(section)
+
+        include_summary = "summary" not in normalized_exclusions
+        base_summary = profile.professional_summary if include_summary else ""
+        optimized_summary = (
+            self._optimize_summary(base_summary, analysis, emphasis)
+            if include_summary
+            else ""
+        )
+        match_improvement = max(0.0, min(1.0, matching.overall_match_score + 0.1))
+
+        optimizations: list[ResumeOptimization] = []
+        if include_summary:
+            optimizations.append(
+                ResumeOptimization(
+                    section="summary",
+                    original_content=base_summary,
+                    optimized_content=optimized_summary,
+                    optimization_reason="Align summary with role title and key technologies",
+                    keywords_added=[word for word in emphasis if word],
+                    match_improvement=round(match_improvement, 2),
+                )
+            )
+
+        markdown = self._compose_markdown(
+            profile,
+            analysis,
+            optimized_summary,
+            matching,
+            normalized_exclusions,
+        )
+
+        change_notes: list[str] = []
+        if include_summary:
+            change_notes.append(
+                "Updated summary to emphasize priority skills and leadership impact."
+            )
+        else:
+            change_notes.append("Removed summary section per preferences.")
+        if "experience" in normalized_exclusions:
+            change_notes.append("Removed experience section per preferences.")
+        if "key matches" in normalized_exclusions:
+            change_notes.append("Removed key match diagnostics per preferences.")
+
+        summary_of_changes = (
+            " ".join(change_notes)
+            if change_notes
+            else "Applied requested preferences to tailored resume."
+        )
+
+        return TailoredResume(
+            job_title=analysis.job_title,
+            company_name=analysis.company_name,
+            optimizations=optimizations,
+            full_resume_markdown=markdown,
+            summary_of_changes=summary_of_changes,
+            estimated_match_score=round(match_improvement, 2),
+            generation_timestamp=timestamp,
+        )
+
+    def _optimize_summary(
+        self, summary: str, analysis: JobAnalysis, emphasis: list[str]
+    ) -> str:
+        highlights = ", ".join({skill.title() for skill in emphasis} or {"Python", "FastAPI"})
+        base = f"Experienced {analysis.job_title} with proven results in {highlights}."
+        if summary:
+            return f"{base} {summary}" if not summary.startswith(base) else summary
+        return base
+
+    def _compose_markdown(
+        self,
+        profile: UserProfile,
+        analysis: JobAnalysis,
+        summary: str,
+        matching: MatchingResult,
+        excluded_sections: set[str],
+    ) -> str:
+        lines: list[str] = [f"# {profile.contact.name}", "", f"**{analysis.job_title}**", ""]
+
+        if "summary" not in excluded_sections and summary:
+            lines.append(summary)
+            lines.append("")
+
+        if "experience" not in excluded_sections and profile.experience:
+            lines.append("## Experience")
+            for exp in profile.experience:
+                lines.append(f"### {exp.position} — {exp.company}")
+                end_label = exp.end_date.strftime("%b %Y") if exp.end_date else "Present"
+                lines.append(f"{exp.start_date:%b %Y} – {end_label}")
+                lines.append(exp.description)
+                for achievement in exp.achievements[:3]:
+                    lines.append(f"- {achievement}")
+                lines.append("")
+
+        show_matches = "key matches" not in excluded_sections
+        if show_matches and matching.skill_matches:
+            lines.append("## Key Matches")
+            for match in matching.skill_matches[:5]:
+                lines.append(f"- {match.skill_name}: match score {match.match_score:.2f}")
+
+        return "\n".join(lines)
+
+
+class ValidationAgent:
+    def __init__(self) -> None:
+        def handler(messages, agent_info):  # type: ignore[override]
+            payload = json.loads(_latest_prompt(messages))
+            analysis = self._analysis_adapter.validate_python(payload["job_analysis"])
+            matching = self._matching_adapter.validate_python(payload["matching_result"])
+            resume = self._resume_adapter.validate_python(payload["tailored_resume"])
+            result = self._validate_output(analysis, matching, resume)
+            return _json_response(result.model_dump(mode="json"))
+
+        self._analysis_adapter: TypeAdapter[JobAnalysis] = TypeAdapter(JobAnalysis)
+        self._matching_adapter: TypeAdapter[MatchingResult] = TypeAdapter(MatchingResult)
+        self._resume_adapter: TypeAdapter[TailoredResume] = TypeAdapter(TailoredResume)
+        self._adapter: TypeAdapter[ValidationResult] = TypeAdapter(ValidationResult)
+        self._agent = LlmAgent(FunctionModel(handler), output_type=str)
+
+    async def validate(
+        self,
+        analysis: JobAnalysis,
+        matching: MatchingResult,
+        resume: TailoredResume,
+    ) -> ValidationResult:
+        payload = {
+            "job_analysis": analysis.model_dump(mode="json"),
+            "matching_result": matching.model_dump(mode="json"),
+            "tailored_resume": resume.model_dump(mode="json"),
+        }
+        result = await self._agent.run(json.dumps(payload))
+        return self._adapter.validate_python(json.loads(result.output))
+
+    def _validate_output(
+        self,
+        analysis: JobAnalysis,
+        matching: MatchingResult,
+        resume: TailoredResume,
+    ) -> ValidationResult:
+        missing_penalty = len(matching.missing_requirements)
+        accuracy = max(0.6, 1.0 - missing_penalty * 0.1)
+        readability = max(0.7, min(0.95, len(resume.full_resume_markdown.split()) / 400))
+        keyword_score = min(0.95, matching.overall_match_score + 0.1)
+        overall = round((accuracy + readability + keyword_score) / 3, 2)
+        timestamp = datetime.now(timezone.utc)
+        strengths = [
+            "Summary aligns with job title",
+            "Key skills emphasized",
+        ]
+        issues = []
+        if missing_penalty:
+            issues.append("Some job requirements lack direct evidence")
+        return ValidationResult(
+            is_valid=accuracy > 0.75,
+            accuracy_score=round(accuracy, 2),
+            readability_score=round(readability, 2),
+            keyword_optimization_score=round(keyword_score, 2),
+            issues=issues,
+            strengths=strengths,
+            overall_quality_score=overall,
+            validation_timestamp=timestamp,
+        )
+
+
+class HumanInterfaceAgent:
+    def __init__(self) -> None:
+        def handler(messages, agent_info):  # type: ignore[override]
+            payload = json.loads(_latest_prompt(messages))
+            matching = self._matching_adapter.validate_python(payload["matching_result"])
+            validation = self._validation_adapter.validate_python(payload["validation_result"])
+            workflow = self._evaluate_workflow(matching, validation)
+            return _json_response(workflow.model_dump(mode="json"))
+
+        self._matching_adapter: TypeAdapter[MatchingResult] = TypeAdapter(MatchingResult)
+        self._validation_adapter: TypeAdapter[ValidationResult] = TypeAdapter(ValidationResult)
+        self._adapter: TypeAdapter[ApprovalWorkflow] = TypeAdapter(ApprovalWorkflow)
+        self._agent = LlmAgent(FunctionModel(handler), output_type=str)
+
+    async def evaluate(
+        self,
+        matching: MatchingResult,
+        validation: ValidationResult,
+    ) -> ApprovalWorkflow:
+        payload = {
+            "matching_result": matching.model_dump(mode="json"),
+            "validation_result": validation.model_dump(mode="json"),
+        }
+        result = await self._agent.run(json.dumps(payload))
+        return self._adapter.validate_python(json.loads(result.output))
+
+    def _evaluate_workflow(
+        self,
+        matching: MatchingResult,
+        validation: ValidationResult,
+    ) -> ApprovalWorkflow:
+        requires_review = matching.overall_match_score < 0.6 or validation.accuracy_score < 0.8
+        review_reasons: list[str] = []
+        if matching.overall_match_score < 0.6:
+            review_reasons.append("Overall match score below threshold")
+        if validation.accuracy_score < 0.8:
+            review_reasons.append("Validation accuracy requires confirmation")
+
+        confidence = round((matching.overall_match_score + validation.overall_quality_score) / 2, 2)
+        auto_approve = not requires_review and confidence >= 0.8
+
+        return ApprovalWorkflow(
+            requires_human_review=requires_review,
+            review_reasons=review_reasons,
+            confidence_score=confidence,
+            auto_approve_eligible=auto_approve,
+        )
+
+
+@dataclass
+class TailoringAgents:
+    job_analysis: JobAnalysisAgent
+    profile_matching: ProfileMatchingAgent
+    resume_generation: ResumeGenerationAgent
+    validation: ValidationAgent
+    human_interface: HumanInterfaceAgent
+
+    @classmethod
+    def default(cls) -> "TailoringAgents":
+        return cls(
+            job_analysis=JobAnalysisAgent(),
+            profile_matching=ProfileMatchingAgent(),
+            resume_generation=ResumeGenerationAgent(),
+            validation=ValidationAgent(),
+            human_interface=HumanInterfaceAgent(),
+        )
+

--- a/src/resume_core/models/__init__.py
+++ b/src/resume_core/models/__init__.py
@@ -1,0 +1,54 @@
+from .job import JobAnalysis, JobRequirement, ResponsibilityLevel
+from .matching import ExperienceMatch, MatchingResult, SkillMatch
+from .profile import (
+    Award,
+    ContactInfo,
+    Education,
+    Language,
+    Project,
+    Publication,
+    Skill,
+    SkillCategory,
+    UserProfile,
+    VolunteerWork,
+    WorkExperience,
+)
+from .resume import (
+    ApprovalResult,
+    ApprovalWorkflow,
+    ResumeHistoryItem,
+    ResumeOptimization,
+    ReviewDecision,
+    TailoredResume,
+    TailoringResult,
+    ValidationResult,
+)
+
+__all__ = [
+    "JobAnalysis",
+    "JobRequirement",
+    "ResponsibilityLevel",
+    "ExperienceMatch",
+    "MatchingResult",
+    "SkillMatch",
+    "Award",
+    "ContactInfo",
+    "Education",
+    "Language",
+    "Project",
+    "Publication",
+    "Skill",
+    "SkillCategory",
+    "UserProfile",
+    "VolunteerWork",
+    "WorkExperience",
+    "ApprovalResult",
+    "ApprovalWorkflow",
+    "ResumeHistoryItem",
+    "ResumeOptimization",
+    "ReviewDecision",
+    "TailoredResume",
+    "TailoringResult",
+    "ValidationResult",
+]
+

--- a/src/resume_core/models/job.py
+++ b/src/resume_core/models/job.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .profile import SkillCategory
+
+
+class ResponsibilityLevel(str, Enum):
+    JUNIOR = "junior"
+    MID = "mid"
+    SENIOR = "senior"
+    LEAD = "lead"
+    EXECUTIVE = "executive"
+
+
+class JobRequirement(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    skill: str
+    importance: int = Field(ge=1, le=5)
+    category: SkillCategory
+    is_required: bool = True
+    context: str
+
+
+class JobAnalysis(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    analysis_id: Optional[UUID] = None
+    company_name: str
+    job_title: str
+    department: Optional[str] = None
+    location: str = "Not specified"
+    remote_policy: Optional[str] = None
+    requirements: List[JobRequirement] = Field(default_factory=list)
+    key_responsibilities: List[str] = Field(default_factory=list)
+    company_culture: str = "Not specified"
+    role_level: ResponsibilityLevel = ResponsibilityLevel.MID
+    industry: str = "technology"
+    salary_range: Optional[str] = None
+    benefits: List[str] = Field(default_factory=list)
+    preferred_qualifications: List[str] = Field(default_factory=list)
+

--- a/src/resume_core/models/matching.py
+++ b/src/resume_core/models/matching.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .job import JobRequirement
+
+
+class SkillMatch(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    skill_name: str
+    job_importance: int
+    user_proficiency: int
+    match_score: float = Field(ge=0.0, le=1.0)
+    evidence: List[str] = Field(default_factory=list)
+
+
+class ExperienceMatch(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    job_responsibility: str
+    matching_experiences: List[str] = Field(default_factory=list)
+    relevance_score: float = Field(ge=0.0, le=1.0)
+
+
+class MatchingResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    overall_match_score: float = Field(ge=0.0, le=1.0)
+    skill_matches: List[SkillMatch] = Field(default_factory=list)
+    experience_matches: List[ExperienceMatch] = Field(default_factory=list)
+    missing_requirements: List[JobRequirement] = Field(default_factory=list)
+    strength_areas: List[str] = Field(default_factory=list)
+    transferable_skills: List[str] = Field(default_factory=list)
+    recommendations: List[str] = Field(default_factory=list)
+

--- a/src/resume_core/models/profile.py
+++ b/src/resume_core/models/profile.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+
+class SkillCategory(str, Enum):
+    TECHNICAL = "technical"
+    SOFT = "soft"
+    LANGUAGE = "language"
+    CERTIFICATION = "certification"
+
+
+class ContactInfo(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(..., description="Full name")
+    email: str = Field(..., description="Primary email address")
+    location: str = Field(..., description="Location such as city and state")
+    phone: Optional[str] = Field(default=None, description="Optional phone number")
+    linkedin: Optional[HttpUrl] = Field(default=None, description="LinkedIn profile URL")
+    portfolio: Optional[HttpUrl] = Field(default=None, description="Portfolio URL")
+
+
+class WorkExperience(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    position: str
+    company: str
+    location: str
+    start_date: date
+    end_date: Optional[date] = None
+    description: str
+    achievements: List[str]
+    technologies: List[str] = Field(default_factory=list)
+
+
+class Education(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    degree: str
+    institution: str
+    location: str
+    graduation_date: date
+    gpa: Optional[float] = None
+    honors: List[str] = Field(default_factory=list)
+    relevant_coursework: List[str] = Field(default_factory=list)
+
+
+class Skill(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    category: SkillCategory
+    proficiency: int = Field(ge=1, le=5)
+    years_experience: Optional[int] = None
+
+
+class Project(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    description: str
+    technologies: List[str]
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    url: Optional[HttpUrl] = None
+
+
+class Publication(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    title: str
+    venue: str
+    date: date
+    url: Optional[HttpUrl] = None
+    authors: List[str] = Field(default_factory=list)
+
+
+class Award(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    title: str
+    organization: str
+    date: date
+    description: Optional[str] = None
+
+
+class VolunteerWork(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    role: str
+    organization: str
+    start_date: date
+    end_date: Optional[date] = None
+    description: str
+
+
+class Language(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    proficiency: str
+
+
+class UserProfile(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    version: str = Field(default="1.0", description="Schema version")
+    metadata: Dict[str, str] = Field(default_factory=dict)
+    contact: ContactInfo
+    professional_summary: str
+    experience: List[WorkExperience]
+    education: List[Education]
+    skills: List[Skill]
+    projects: List[Project] = Field(default_factory=list)
+    publications: List[Publication] = Field(default_factory=list)
+    awards: List[Award] = Field(default_factory=list)
+    volunteer: List[VolunteerWork] = Field(default_factory=list)
+    languages: List[Language] = Field(default_factory=list)
+

--- a/src/resume_core/models/resume.py
+++ b/src/resume_core/models/resume.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+from .job import JobAnalysis
+from .matching import MatchingResult
+
+
+class ResumeOptimization(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    section: str
+    original_content: str
+    optimized_content: str
+    optimization_reason: str
+    keywords_added: List[str] = Field(default_factory=list)
+    match_improvement: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class TailoredResume(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    job_title: str
+    company_name: str
+    optimizations: List[ResumeOptimization] = Field(default_factory=list)
+    full_resume_markdown: str
+    summary_of_changes: str
+    estimated_match_score: float = Field(ge=0.0, le=1.0)
+    generation_timestamp: datetime
+
+
+class ValidationResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    is_valid: bool
+    accuracy_score: float = Field(ge=0.0, le=1.0)
+    readability_score: float = Field(ge=0.0, le=1.0)
+    keyword_optimization_score: float = Field(ge=0.0, le=1.0)
+    issues: List[str] = Field(default_factory=list)
+    strengths: List[str] = Field(default_factory=list)
+    overall_quality_score: float = Field(ge=0.0, le=1.0)
+    validation_timestamp: datetime
+
+
+class ApprovalWorkflow(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    requires_human_review: bool
+    review_reasons: List[str] = Field(default_factory=list)
+    confidence_score: float = Field(ge=0.0, le=1.0)
+    auto_approve_eligible: bool
+
+
+class TailoringResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    resume_id: UUID
+    job_analysis: JobAnalysis
+    matching_result: MatchingResult
+    tailored_resume: TailoredResume
+    validation_result: ValidationResult
+    approval_workflow: ApprovalWorkflow
+
+
+class ReviewDecision(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    decision: str = Field(pattern="^(pending|approved|rejected|needs_revision)$")
+    feedback: Optional[str] = None
+    requested_modifications: List[str] = Field(default_factory=list)
+    approved_sections: List[str] = Field(default_factory=list)
+    rejected_sections: List[str] = Field(default_factory=list)
+
+
+class ApprovalResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    status: str
+    final_resume_url: Optional[HttpUrl] = None
+    revision_needed: bool
+    next_steps: List[str] = Field(default_factory=list)
+
+
+class ResumeHistoryItem(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    resume_id: UUID
+    job_title: str
+    company_name: str
+    created_at: datetime
+    status: str
+    match_score: float = Field(ge=0.0, le=1.0)
+

--- a/src/resume_core/services/__init__.py
+++ b/src/resume_core/services/__init__.py
@@ -1,3 +1,25 @@
 from resume_core.services.analysis import AnalysisService
+from resume_core.services.profile import ProfileStore
+from resume_core.services.tailoring import (
+    ProfileNotFoundError,
+    JobAnalysisNotFoundError,
+    ResumeNotFoundError,
+    ResumeTailoringService,
+    ResumeNotApprovedError,
+    TailoringPreferences,
+    UnsupportedFormatError,
+    validate_preferences,
+)
 
-__all__ = ["AnalysisService"]
+__all__ = [
+    "AnalysisService",
+    "ProfileStore",
+    "ResumeTailoringService",
+    "TailoringPreferences",
+    "validate_preferences",
+    "JobAnalysisNotFoundError",
+    "ProfileNotFoundError",
+    "ResumeNotFoundError",
+    "ResumeNotApprovedError",
+    "UnsupportedFormatError",
+]

--- a/src/resume_core/services/profile.py
+++ b/src/resume_core/services/profile.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from pydantic import TypeAdapter
+
+from resume_core.models.profile import UserProfile
+
+
+class ProfileStore:
+    """File-backed storage for the single user profile."""
+
+    def __init__(self, base_path: Path | str | None = None) -> None:
+        if base_path is None:
+            env_dir = os.environ.get("RESUME_ASSISTANT_DATA_DIR")
+            if env_dir:
+                base_path = Path(env_dir)
+            else:
+                base_path = Path.home() / ".resume-assistant"
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self._profile_path = self.base_path / "profile.json"
+        self._adapter: TypeAdapter[UserProfile] = TypeAdapter(UserProfile)
+
+    @property
+    def profile_path(self) -> Path:
+        return self._profile_path
+
+    def get_profile(self) -> UserProfile | None:
+        if not self._profile_path.exists():
+            return None
+        data = json.loads(self._profile_path.read_text(encoding="utf-8"))
+        return self._adapter.validate_python(data)
+
+    def save_profile(self, profile: UserProfile | dict[str, Any]) -> UserProfile:
+        profile_model = self._adapter.validate_python(profile)
+        self._profile_path.write_text(
+            profile_model.model_dump_json(indent=2, exclude_none=True),
+            encoding="utf-8",
+        )
+        return profile_model
+

--- a/src/resume_core/services/tailoring.py
+++ b/src/resume_core/services/tailoring.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, List, Tuple
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field, ValidationError
+
+from resume_core.agents.tailoring import TailoringAgents
+from resume_core.models import (
+    ApprovalResult,
+    ApprovalWorkflow,
+    JobAnalysis,
+    ResumeHistoryItem,
+    ReviewDecision,
+    TailoringResult,
+    ValidationResult,
+)
+from resume_core.services.profile import ProfileStore
+
+
+class TailoringPreferences(BaseModel):
+    emphasis_areas: List[str] = Field(default_factory=list)
+    excluded_sections: List[str] = Field(default_factory=list)
+
+
+class ProfileNotFoundError(RuntimeError):
+    """Raised when the profile has not been configured yet."""
+
+
+class ResumeNotFoundError(RuntimeError):
+    """Raised when a resume identifier cannot be located."""
+
+
+class UnsupportedFormatError(RuntimeError):
+    """Raised when a download format is not implemented."""
+
+
+class JobAnalysisNotFoundError(RuntimeError):
+    """Raised when a supplied job analysis identifier is unknown."""
+
+
+class ResumeNotApprovedError(RuntimeError):
+    """Raised when attempting to download a resume before approval."""
+
+
+@dataclass
+class ResumeRecord:
+    result: TailoringResult
+    status: str
+
+
+class ResumeTailoringService:
+    def __init__(
+        self,
+        profile_store: ProfileStore | None = None,
+        *,
+        agents: TailoringAgents | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.profile_store = profile_store or ProfileStore()
+        self.agents = agents or TailoringAgents.default()
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._resumes: Dict[UUID, ResumeRecord] = {}
+        self._history: List[ResumeHistoryItem] = []
+        self._history_index: Dict[UUID, int] = {}
+        self._job_analyses: Dict[UUID, JobAnalysis] = {}
+
+    async def analyze_job(self, job_description: str) -> JobAnalysis:
+        if not job_description or not job_description.strip():
+            raise ValueError("Job description cannot be empty")
+        analysis = await self.agents.job_analysis.analyze(job_description)
+        analysis_id = uuid4()
+        analysis_with_id = analysis.model_copy(update={"analysis_id": analysis_id})
+        self._job_analyses[analysis_id] = analysis_with_id
+        return analysis_with_id
+
+    async def tailor_resume(
+        self,
+        *,
+        job_description: str,
+        job_analysis_id: UUID | None = None,
+        preferences: TailoringPreferences | None = None,
+    ) -> TailoringResult:
+        profile = self.profile_store.get_profile()
+        if profile is None:
+            raise ProfileNotFoundError("User profile not configured")
+
+        if job_analysis_id is not None:
+            analysis = self._get_stored_analysis(job_analysis_id)
+        else:
+            analysis = await self.analyze_job(job_description)
+        matching = await self.agents.profile_matching.match(analysis, profile)
+        preferences_dict = (preferences or TailoringPreferences()).model_dump()
+        timestamp = self._clock()
+        resume = await self.agents.resume_generation.generate(
+            analysis=analysis,
+            matching=matching,
+            profile=profile,
+            preferences=preferences_dict,
+            timestamp=timestamp,
+        )
+        validation = await self.agents.validation.validate(analysis, matching, resume)
+        workflow = await self.agents.human_interface.evaluate(matching, validation)
+
+        resume_id = uuid4()
+        result = TailoringResult(
+            resume_id=resume_id,
+            job_analysis=analysis,
+            matching_result=matching,
+            tailored_resume=resume,
+            validation_result=validation,
+            approval_workflow=workflow,
+        )
+
+        status = self._initial_status(workflow)
+        record = ResumeRecord(result=result, status=status)
+        self._resumes[resume_id] = record
+        history_item = ResumeHistoryItem(
+            resume_id=resume_id,
+            job_title=analysis.job_title,
+            company_name=analysis.company_name,
+            created_at=timestamp,
+            status=status,
+            match_score=matching.overall_match_score,
+        )
+        self._history_index[resume_id] = len(self._history)
+        self._history.append(history_item)
+        return result
+
+    async def approve_resume(self, resume_id: UUID, decision: ReviewDecision) -> ApprovalResult:
+        record = self._resumes.get(resume_id)
+        if record is None:
+            raise ResumeNotFoundError(f"Resume {resume_id} not found")
+
+        decision_value = decision.decision
+        status = decision_value
+        revision_needed = decision_value in {"needs_revision", "rejected"}
+        final_url = None
+        if decision_value == "approved":
+            final_url = f"http://localhost:8000/resumes/{resume_id}/download"
+            revision_needed = False
+
+        next_steps = self._determine_next_steps(decision_value, decision, record.result)
+        approval = ApprovalResult(
+            status=decision_value,
+            final_resume_url=final_url,
+            revision_needed=revision_needed,
+            next_steps=next_steps,
+        )
+
+        record.status = status
+        history_index = self._history_index.get(resume_id)
+        if history_index is not None:
+            self._history[history_index] = self._history[history_index].model_copy(update={"status": status})
+
+        return approval
+
+    def get_history(self, *, limit: int, offset: int) -> Tuple[List[ResumeHistoryItem], int]:
+        total = len(self._history)
+        start = min(offset, total)
+        end = min(start + max(limit, 1), total)
+        return self._history[start:end], total
+
+    def get_result(self, resume_id: UUID) -> TailoringResult:
+        record = self._resumes.get(resume_id)
+        if record is None:
+            raise ResumeNotFoundError(f"Resume {resume_id} not found")
+        return record.result
+
+    def get_resume_markdown(self, resume_id: UUID) -> str:
+        result = self.get_result(resume_id)
+        return result.tailored_resume.full_resume_markdown
+
+    def download_resume(self, resume_id: UUID, format_: str) -> str:
+        record = self._resumes.get(resume_id)
+        if record is None:
+            raise ResumeNotFoundError(f"Resume {resume_id} not found")
+        if record.status != "approved":
+            raise ResumeNotApprovedError(
+                f"Resume {resume_id} is not approved for download"
+            )
+        if format_ != "markdown":
+            raise UnsupportedFormatError(f"Format '{format_}' is not supported")
+        return record.result.tailored_resume.full_resume_markdown
+
+    def _initial_status(self, workflow: ApprovalWorkflow) -> str:
+        if workflow.auto_approve_eligible and not workflow.requires_human_review:
+            return "approved"
+        return "pending"
+
+    def _determine_next_steps(
+        self,
+        decision: str,
+        payload: ReviewDecision,
+        result: TailoringResult,
+    ) -> List[str]:
+        company = result.job_analysis.company_name or "the target company"
+        if decision == "approved":
+            return [
+                "Download your tailored resume",
+                "Review final formatting",
+                f"Submit your application to {company}",
+            ]
+        if decision == "needs_revision":
+            return payload.requested_modifications or [
+                "Provide additional details for missing requirements",
+                "Clarify achievements for highlighted sections",
+            ]
+        if decision == "rejected":
+            return ["Review feedback and consider generating a new version"]
+        return ["Awaiting further review"]
+
+    def _get_stored_analysis(self, analysis_id: UUID) -> JobAnalysis:
+        analysis = self._job_analyses.get(analysis_id)
+        if analysis is None:
+            raise JobAnalysisNotFoundError(f"Job analysis {analysis_id} not found")
+        return analysis.model_copy(deep=True)
+
+
+def validate_preferences(data: dict | None) -> TailoringPreferences:
+    if data is None:
+        return TailoringPreferences()
+    try:
+        return TailoringPreferences.model_validate(data)
+    except ValidationError as exc:  # pragma: no cover - FastAPI surfaces the error
+        raise exc
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator
 from unittest.mock import patch
 
 import pytest

--- a/tests/integration/test_resume_tailoring_api.py
+++ b/tests/integration/test_resume_tailoring_api.py
@@ -1,0 +1,142 @@
+from datetime import date
+from uuid import UUID
+
+import pytest
+
+from resume_core.models.profile import (
+    ContactInfo,
+    Education,
+    Skill,
+    SkillCategory,
+    UserProfile,
+    WorkExperience,
+)
+from resume_core.services.profile import ProfileStore
+from resume_core.services.tailoring import ResumeTailoringService
+
+
+def build_profile() -> dict:
+    profile = UserProfile(
+        version="1.0",
+        metadata={"created_at": "2024-01-01T00:00:00Z"},
+        contact=ContactInfo(name="John Developer", email="john@example.com", location="San Francisco, CA"),
+        professional_summary="Backend engineer with 6 years of experience building APIs.",
+        experience=[
+            WorkExperience(
+                position="Senior Software Engineer",
+                company="StartupXYZ",
+                location="San Francisco, CA",
+                start_date=date(2020, 1, 1),
+                end_date=None,
+                description="Lead backend engineer driving platform improvements.",
+                achievements=["Improved system reliability by 30%"],
+                technologies=["Python", "FastAPI", "PostgreSQL", "AWS"],
+            )
+        ],
+        education=[
+            Education(
+                degree="B.S. Computer Science",
+                institution="UC Berkeley",
+                location="Berkeley, CA",
+                graduation_date=date(2018, 5, 15),
+            )
+        ],
+        skills=[
+            Skill(name="Python", category=SkillCategory.TECHNICAL, proficiency=5, years_experience=6),
+            Skill(name="FastAPI", category=SkillCategory.TECHNICAL, proficiency=4, years_experience=4),
+            Skill(name="PostgreSQL", category=SkillCategory.TECHNICAL, proficiency=4, years_experience=4),
+        ],
+        projects=[],
+        publications=[],
+        awards=[],
+        volunteer=[],
+        languages=[],
+    )
+    return profile.model_dump(mode="json")
+
+
+@pytest.mark.asyncio
+async def test_resume_tailoring_flow(async_client, monkeypatch, tmp_path):
+    monkeypatch.setenv("RESUME_ASSISTANT_DATA_DIR", str(tmp_path))
+
+    from app.api import deps
+    from app.main import app
+
+    store = ProfileStore(base_path=tmp_path)
+    service = ResumeTailoringService(profile_store=store)
+    app.dependency_overrides[deps.get_tailoring_service] = lambda: service
+
+    payload = build_profile()
+    response = await async_client.put("/api/v1/profile", json=payload)
+    assert response.status_code == 200
+
+    job_desc = {
+        "job_description": (
+            "Senior Software Engineer wanted.\n"
+            "ExampleCorp\n"
+            "- Python expertise required.\n"
+            "- FastAPI experience required.\n"
+            "- PostgreSQL experience required.\n"
+            "- Demonstrated leadership in cross-functional teams.\n"
+            "- Excellent communication skills with stakeholders.\n"
+            "- Prior experience with Kubernetes and Terraform."
+        )
+    }
+    response = await async_client.post("/api/v1/jobs/analyze", json=job_desc)
+    assert response.status_code == 200
+    analysis = response.json()
+    assert analysis["job_title"] == "Senior Software Engineer"
+    assert any(req["skill"].lower() == "python" for req in analysis["requirements"])
+    assert analysis["company_culture"] in {"collaborative environment", "Not specified"}
+    assert "analysis_id" in analysis
+
+    tailor_request = {
+        "job_description": job_desc["job_description"],
+        "job_analysis_id": analysis["analysis_id"],
+        "preferences": {"emphasis_areas": ["Python"], "excluded_sections": ["key_matches"]},
+    }
+    response = await async_client.post("/api/v1/resumes/tailor", json=tailor_request)
+    assert response.status_code == 200
+    result = response.json()
+    resume_id = UUID(result["resume_id"])
+    assert result["matching_result"]["recommendations"]
+    assert result["job_analysis"]["analysis_id"] == analysis["analysis_id"]
+
+    response = await async_client.get(
+        f"/api/v1/resumes/{resume_id}/download", params={"format": "markdown"}
+    )
+    if result["approval_workflow"]["requires_human_review"]:
+        assert response.status_code == 403
+    else:
+        assert response.status_code == 200
+
+    decision_payload = {
+        "decision": "approved",
+        "feedback": "Ship it",
+        "approved_sections": ["summary", "experience"],
+    }
+    response = await async_client.post(f"/api/v1/resumes/{resume_id}/approve", json=decision_payload)
+    assert response.status_code == 200
+    approval = response.json()
+    assert approval["status"] == "approved"
+    assert not approval["revision_needed"]
+    assert approval["next_steps"] == [
+        "Download your tailored resume",
+        "Review final formatting",
+        "Submit your application to ExampleCorp",
+    ]
+
+    response = await async_client.get(
+        f"/api/v1/resumes/{resume_id}/download", params={"format": "markdown"}
+    )
+    assert response.status_code == 200
+    assert "John Developer" in response.text
+    assert "## Key Matches" not in response.text
+
+    response = await async_client.get("/api/v1/resumes/history")
+    assert response.status_code == 200
+    history = response.json()
+    assert history["total"] == 1
+    assert UUID(history["resumes"][0]["resume_id"]) == resume_id
+
+    app.dependency_overrides.pop(deps.get_tailoring_service, None)

--- a/tests/integration/test_sample_route.py
+++ b/tests/integration/test_sample_route.py
@@ -8,7 +8,8 @@ async def test_health_endpoint_integration(async_client: AsyncClient):
     assert response.status_code == 200
     data = response.json()
     assert "status" in data
-    assert data["status"] == "ok"
+    assert data["status"] == "healthy"
+    assert "timestamp" in data
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -6,4 +6,6 @@ from httpx import AsyncClient
 async def test_health_check(async_client: AsyncClient):
     response = await async_client.get("/api/v1/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    payload = response.json()
+    assert payload["status"] == "healthy"
+    assert "timestamp" in payload

--- a/tests/unit/test_profile_service.py
+++ b/tests/unit/test_profile_service.py
@@ -1,0 +1,81 @@
+from datetime import date
+
+from resume_core.models.profile import (
+    ContactInfo,
+    Education,
+    Skill,
+    SkillCategory,
+    UserProfile,
+    WorkExperience,
+)
+from resume_core.services.profile import ProfileStore
+
+
+def build_profile() -> UserProfile:
+    return UserProfile(
+        version="1.0",
+        metadata={"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-10T00:00:00Z"},
+        contact=ContactInfo(
+            name="John Developer",
+            email="john@example.com",
+            location="San Francisco, CA",
+            phone="555-123-4567",
+            linkedin="https://linkedin.com/in/johndeveloper",
+        ),
+        professional_summary="Experienced engineer with a focus on backend services and infrastructure.",
+        experience=[
+            WorkExperience(
+                position="Software Engineer",
+                company="StartupXYZ",
+                location="San Francisco, CA",
+                start_date=date(2019, 1, 15),
+                end_date=None,
+                description="Led development of scalable backend systems.",
+                achievements=[
+                    "Reduced API latency by 35% through caching and profiling",
+                    "Implemented CI/CD pipelines to ship features twice as fast",
+                ],
+                technologies=["Python", "FastAPI", "PostgreSQL", "Docker"],
+            )
+        ],
+        education=[
+            Education(
+                degree="B.S. Computer Science",
+                institution="UC Berkeley",
+                location="Berkeley, CA",
+                graduation_date=date(2018, 5, 15),
+                honors=["Magna Cum Laude"],
+                relevant_coursework=["Distributed Systems", "Machine Learning"],
+            )
+        ],
+        skills=[
+            Skill(name="Python", category=SkillCategory.TECHNICAL, proficiency=5, years_experience=6),
+            Skill(name="FastAPI", category=SkillCategory.TECHNICAL, proficiency=4, years_experience=3),
+            Skill(name="PostgreSQL", category=SkillCategory.TECHNICAL, proficiency=4, years_experience=4),
+            Skill(name="AWS", category=SkillCategory.TECHNICAL, proficiency=3, years_experience=3),
+        ],
+        projects=[],
+        publications=[],
+        awards=[],
+        volunteer=[],
+        languages=[],
+    )
+
+
+def test_profile_store_round_trip(tmp_path) -> None:
+    store = ProfileStore(base_path=tmp_path)
+
+    profile = build_profile()
+    saved = store.save_profile(profile)
+
+    assert saved.contact.name == "John Developer"
+    assert (tmp_path / "profile.json").exists()
+
+    loaded = store.get_profile()
+    assert loaded == profile
+
+
+def test_profile_store_returns_none_when_missing(tmp_path) -> None:
+    store = ProfileStore(base_path=tmp_path)
+
+    assert store.get_profile() is None

--- a/tests/unit/test_tailoring_pipeline.py
+++ b/tests/unit/test_tailoring_pipeline.py
@@ -1,0 +1,188 @@
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from resume_core.models.profile import (
+    ContactInfo,
+    Education,
+    Skill,
+    SkillCategory,
+    UserProfile,
+    WorkExperience,
+)
+from resume_core.models.resume import ReviewDecision
+from resume_core.services.profile import ProfileStore
+from resume_core.services.tailoring import (
+    JobAnalysisNotFoundError,
+    ResumeNotApprovedError,
+    ResumeTailoringService,
+    TailoringPreferences,
+)
+
+
+JOB_DESCRIPTION = """
+Senior Software Engineer - Backend Platform
+TechCorp Inc.
+
+We are looking for an experienced backend engineer to build scalable services.
+You will collaborate with a cross-functional team to deliver platform features.
+
+Requirements:
+- 5+ years of Python experience
+- Strong knowledge of FastAPI
+- Experience with PostgreSQL databases
+- Familiarity with AWS cloud services
+
+Preferred Qualifications:
+- Experience with Kubernetes
+- Experience leading engineering projects
+""".strip()
+
+
+def build_profile() -> UserProfile:
+    return UserProfile(
+        version="1.0",
+        metadata={"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-02-01T00:00:00Z"},
+        contact=ContactInfo(
+            name="John Developer",
+            email="john@example.com",
+            location="San Francisco, CA",
+        ),
+        professional_summary="Backend engineer with 6 years of experience building scalable APIs.",
+        experience=[
+            WorkExperience(
+                position="Senior Software Engineer",
+                company="StartupXYZ",
+                location="San Francisco, CA",
+                start_date=date(2020, 6, 1),
+                end_date=None,
+                description="Leads backend platform team shipping reliable services.",
+                achievements=[
+                    "Scaled API throughput by 3x while reducing latency",
+                    "Introduced observability stack improving MTTR by 40%",
+                ],
+                technologies=["Python", "FastAPI", "PostgreSQL", "AWS"],
+            )
+        ],
+        education=[
+            Education(
+                degree="B.S. Computer Science",
+                institution="UC Berkeley",
+                location="Berkeley, CA",
+                graduation_date=date(2018, 5, 15),
+            )
+        ],
+        skills=[
+            Skill(name="Python", category=SkillCategory.TECHNICAL, proficiency=5, years_experience=6),
+            Skill(name="FastAPI", category=SkillCategory.TECHNICAL, proficiency=4, years_experience=4),
+            Skill(name="PostgreSQL", category=SkillCategory.TECHNICAL, proficiency=4, years_experience=4),
+            Skill(name="AWS", category=SkillCategory.TECHNICAL, proficiency=3, years_experience=3),
+        ],
+        projects=[],
+        publications=[],
+        awards=[],
+        volunteer=[],
+        languages=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_tailoring_pipeline_generates_resume(tmp_path) -> None:
+    store = ProfileStore(base_path=tmp_path)
+    store.save_profile(build_profile())
+
+    pipeline = ResumeTailoringService(profile_store=store)
+
+    analysis = await pipeline.analyze_job(JOB_DESCRIPTION)
+    assert analysis.job_title.startswith("Senior Software Engineer")
+    assert any(req.skill.lower() == "python" for req in analysis.requirements)
+    assert any(req.skill == "Kubernetes" for req in analysis.requirements)
+    kubernetes_reqs = [req for req in analysis.requirements if req.skill == "Kubernetes"]
+    assert kubernetes_reqs and not kubernetes_reqs[0].is_required
+    assert any("Kubernetes" in pref for pref in analysis.preferred_qualifications)
+    assert analysis.company_culture == "collaborative environment"
+    assert analysis.analysis_id is not None
+
+    preferences = TailoringPreferences(emphasis_areas=["Python", "FastAPI"], excluded_sections=[])
+    result = await pipeline.tailor_resume(
+        job_description=JOB_DESCRIPTION,
+        job_analysis_id=analysis.analysis_id,
+        preferences=preferences,
+    )
+
+    assert result.resume_id in pipeline._resumes  # stored for future approval
+    assert result.tailored_resume.full_resume_markdown.startswith("# John Developer")
+    assert result.matching_result.overall_match_score >= 0.0
+    assert result.matching_result.recommendations
+    assert result.validation_result.is_valid
+    assert result.job_analysis.analysis_id == analysis.analysis_id
+
+    history, total = pipeline.get_history(limit=5, offset=0)
+    assert total == 1
+    assert history[0].resume_id == result.resume_id
+
+    decision = ReviewDecision(decision="approved", feedback="Looks good", approved_sections=["summary"])
+    approval = await pipeline.approve_resume(result.resume_id, decision)
+    assert approval.status == "approved"
+    assert not approval.revision_needed
+    assert approval.next_steps == [
+        "Download your tailored resume",
+        "Review final formatting",
+        "Submit your application to TechCorp Inc.",
+    ]
+
+    markdown = pipeline.get_resume_markdown(result.resume_id)
+    assert "Senior Software Engineer" in markdown
+
+
+@pytest.mark.asyncio
+async def test_tailoring_respects_exclusions_and_download_guard(tmp_path) -> None:
+    store = ProfileStore(base_path=tmp_path)
+    store.save_profile(build_profile())
+
+    pipeline = ResumeTailoringService(profile_store=store)
+
+    analysis = await pipeline.analyze_job(JOB_DESCRIPTION)
+    assert analysis.analysis_id is not None
+
+    preferences = TailoringPreferences(
+        emphasis_areas=["Python"],
+        excluded_sections=["summary", "key_matches"],
+    )
+    result = await pipeline.tailor_resume(
+        job_description=JOB_DESCRIPTION,
+        job_analysis_id=analysis.analysis_id,
+        preferences=preferences,
+    )
+
+    markdown = result.tailored_resume.full_resume_markdown
+    assert "## Key Matches" not in markdown
+    assert "## Experience" in markdown
+    assert result.tailored_resume.optimizations == []
+    assert "Removed summary section per preferences." in result.tailored_resume.summary_of_changes
+
+    with pytest.raises(ResumeNotApprovedError):
+        pipeline.download_resume(result.resume_id, "markdown")
+
+    await pipeline.approve_resume(
+        result.resume_id,
+        ReviewDecision(decision="approved", feedback="Proceed"),
+    )
+    content = pipeline.download_resume(result.resume_id, "markdown")
+    assert "# John Developer" in content
+
+
+@pytest.mark.asyncio
+async def test_tailoring_rejects_unknown_job_analysis_id(tmp_path) -> None:
+    store = ProfileStore(base_path=tmp_path)
+    store.save_profile(build_profile())
+
+    pipeline = ResumeTailoringService(profile_store=store)
+
+    with pytest.raises(JobAnalysisNotFoundError):
+        await pipeline.tailor_resume(
+            job_description=JOB_DESCRIPTION,
+            job_analysis_id=uuid4(),
+            preferences=TailoringPreferences(),
+        )


### PR DESCRIPTION
## Summary
- persist job analyses with generated IDs so tailoring requests can reuse prior analysis data and align the OpenAPI contract
- require resumes to be approved before download, returning 403 for pending artifacts while wiring the API to surface missing analysis errors
- honor excluded section preferences in the generation agent and refresh tests/documentation to cover the new workflow behaviors

## Testing
- `uv run pytest`
- Manual quickstart smoke test covering health, profile setup, job analysis, tailoring with reuse, approval, gated download, and history lookup

------
https://chatgpt.com/codex/tasks/task_e_68cb4c40d6888333bcb1773726c5b6a2