### PR TITLE
feat: add conversational chat endpoint

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,3 +57,29 @@ def test_validate_endpoint_scores_resume():
     data = response.json()
     assert 0 <= data["ats_compatibility"] <= 1
     assert 0 <= data["keyword_density"] <= 1
+
+
+def test_chat_endpoint_returns_grounded_response():
+    client = build_client()
+    payload = {
+        "messages": [
+            {"role": "user", "content": "How can I talk about achievements?"},
+        ]
+    }
+
+    response = client.post("/chat", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["reply"]["role"] == "assistant"
+    assert "resume playbook" in data["reply"]["content"].lower()
+    assert data["reply"].get("metadata", {}).get("grounding")
+    assert data["session"]["turns"] == 1
+
+
+def test_chat_endpoint_requires_messages():
+    client = build_client()
+
+    response = client.post("/chat", json={"messages": []})
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- define chat message schemas and expose a POST /chat endpoint that uses the existing generator
- extend ResumeGenerator with a chat helper that grounds replies on stored playbook guidance
- cover the chat workflow and validation errors with new API tests

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68cde19b79088333a12ccd6f7e2bbd8a