### PR TITLE
feat: add conversational chat endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,19 @@ uv sync
 uv run uvicorn main:app --reload
 ```
 
-The service exposes two endpoints:
+The service exposes three primary endpoints:
 
 - `POST /generate` – Accepts a job posting and user profile, returning a structured resume with metadata, citations, and confidence scores.
 - `POST /validate` – Scores raw resume text for ATS compatibility, keyword density, and readability.
+- `POST /chat` – Provides a conversational helper that suggests how to tailor your résumé. It expects a JSON payload with a `message` string and optional `history` array of `{role, content}` objects, returning the assistant `reply` alongside the updated conversation history.
 
 A helper `GET /health` endpoint returns a simple status payload.
+
+### Using the Chat UI
+
+The FastAPI app also serves a lightweight web chat interface that talks to the `/chat` endpoint. Once the server is running, open
+`http://localhost:8000/` in a browser to load the UI. Static assets are bundled in `app/frontend` and exposed from the same
+FastAPI process, so no additional build step is required.
 
 ### Docker Compose
 A production-friendly stack is available via Docker Compose:

--- a/app/frontend/chat.js
+++ b/app/frontend/chat.js
@@ -1,0 +1,86 @@
+const API_URL = "/chat";
+
+const chatLog = document.getElementById("chat-log");
+const chatForm = document.getElementById("chat-form");
+const messageInput = document.getElementById("message-input");
+
+let conversationHistory = [];
+
+function createMessageElement(role, content) {
+  const message = document.createElement("section");
+  message.classList.add("message", `message-${role}`);
+
+  const roleLabel = document.createElement("span");
+  roleLabel.classList.add("message-role");
+  roleLabel.textContent = role === "user" ? "You" : role === "assistant" ? "Assistant" : "System";
+
+  const text = document.createElement("p");
+  text.classList.add("message-content");
+  text.textContent = content;
+
+  message.append(roleLabel, text);
+  return message;
+}
+
+function appendMessage(role, content) {
+  const element = createMessageElement(role, content);
+  chatLog.appendChild(element);
+  chatLog.scrollTo({ top: chatLog.scrollHeight, behavior: "smooth" });
+}
+
+async function sendMessage(event) {
+  event.preventDefault();
+  const message = messageInput.value.trim();
+  if (!message) {
+    return;
+  }
+
+  const payloadHistory = [...conversationHistory];
+  appendMessage("user", message);
+  messageInput.value = "";
+
+  try {
+    const response = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message,
+        history: payloadHistory,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+    const reply = data.reply ?? data.message ?? data.response ?? "The assistant returned an empty response.";
+
+    appendMessage("assistant", reply);
+
+    if (Array.isArray(data.history)) {
+      conversationHistory = data.history;
+    } else {
+      conversationHistory = [
+        ...payloadHistory,
+        { role: "user", content: message },
+        { role: "assistant", content: reply },
+      ];
+    }
+  } catch (error) {
+    appendMessage("system", error.message || "Unknown error");
+  }
+}
+
+if (chatForm) {
+  chatForm.addEventListener("submit", sendMessage);
+}
+
+if (chatLog) {
+  const welcomeMessage =
+    "Hi! I'm your resume assistant. Share a job posting and your experience so I can suggest how to tailor your résumé.";
+  appendMessage("assistant", welcomeMessage);
+  conversationHistory.push({ role: "assistant", content: welcomeMessage });
+}

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Resume Assistant Chat</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="chat-container">
+      <header class="chat-header">
+        <h1>Resume Assistant</h1>
+        <p class="chat-subtitle">
+          Chat with the AI assistant about tailoring your resume.
+        </p>
+      </header>
+      <main id="chat-log" class="chat-log" aria-live="polite"></main>
+      <form id="chat-form" class="chat-form" autocomplete="off">
+        <label class="sr-only" for="message-input">Type your message</label>
+        <input
+          id="message-input"
+          name="message"
+          class="chat-input"
+          placeholder="Ask for resume tips or paste a job description..."
+          required
+        />
+        <button type="submit" class="chat-submit">Send</button>
+      </form>
+    </div>
+    <script src="/static/chat.js" type="module"></script>
+  </body>
+</html>

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -1,0 +1,165 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #f5f5f5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #f7fafc 0%, #e3f2fd 100%);
+}
+
+.chat-container {
+  width: min(720px, 90vw);
+  min-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  background-color: rgba(255, 255, 255, 0.9);
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.15);
+  overflow: hidden;
+}
+
+.chat-header {
+  padding: 24px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+}
+
+.chat-header h1 {
+  margin: 0 0 4px;
+  font-size: 1.75rem;
+}
+
+.chat-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.chat-log {
+  flex: 1;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  background: rgba(241, 245, 249, 0.6);
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 12px;
+  line-height: 1.5;
+  font-size: 0.95rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message-role {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  opacity: 0.7;
+}
+
+.message-content {
+  margin: 0;
+}
+
+.message-user {
+  margin-left: auto;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.25);
+}
+
+.message-assistant {
+  margin-right: auto;
+  background-color: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: #0f172a;
+}
+
+.message-system {
+  margin: 0 auto;
+  background-color: rgba(248, 113, 113, 0.1);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #b91c1c;
+}
+
+.chat-form {
+  display: flex;
+  gap: 12px;
+  padding: 20px 24px 24px;
+  background-color: rgba(255, 255, 255, 0.95);
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.chat-input {
+  flex: 1;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.chat-submit {
+  padding: 0 24px;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.chat-submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.3);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .chat-container {
+    min-height: 100vh;
+    width: 100vw;
+    border-radius: 0;
+  }
+
+  .chat-form {
+    flex-direction: column;
+  }
+
+  .chat-submit {
+    width: 100%;
+    padding: 14px;
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,3 +57,28 @@ def test_validate_endpoint_scores_resume():
     data = response.json()
     assert 0 <= data["ats_compatibility"] <= 1
     assert 0 <= data["keyword_density"] <= 1
+
+
+def test_frontend_served_at_root():
+    client = build_client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert "chat-container" in response.text
+
+
+def test_chat_endpoint_returns_conversational_reply():
+    client = build_client()
+    payload = {
+        "message": "How should I improve the summary for an SRE role?",
+        "history": [
+            {"role": "assistant", "content": "Welcome to the resume assistant!"},
+        ],
+    }
+    response = client.post("/chat", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["reply"].startswith("Thanks for")
+    assert len(data["history"]) == len(payload["history"]) + 2
+    assert data["history"][-1]["role"] == "assistant"
+    assert any(entry["role"] == "user" for entry in data["history"])


### PR DESCRIPTION
## Summary
- add chat request/response models and expose a /chat route that returns tailored resume coaching replies
- initialise the web chat with a welcome message and sync the payload format with the backend history contract
- document the chat API contract and cover it with an integration test

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68cde1cdc9d48333b1685e3b54117691