### PR TITLE
ci: switch release workflow to semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,50 +1,68 @@
-name: Release automation
+name: release
 
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch:
-  release:
-    types: [published]
+    branches: [ main ]
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  release-please:
-    if: github.event_name != 'release'
+  release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
-      - name: Run release-please
-        uses: google-github-actions/release-please-action@v4
+      - uses: actions/checkout@v5
         with:
-          release-type: python
-          package-name: resume-assistant
-          default-branch: main
+          fetch-depth: 0
 
-  build-and-push-image:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm install --frozen-lockfile
+
+      - name: Semantic Release
+        id: sr
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/github
+            @semantic-release/npm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image name
+        id: img
+        run: |
+          owner=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          repo=$(echo "${GITHUB_REPOSITORY#*/}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE=ghcr.io/${owner}/${repo}" >> "$GITHUB_OUTPUT"
+
+      - name: Build metadata
+        id: meta
+        run: echo "NOW=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+      - name: Derive short SHA
+        id: sha
+        run: echo "SHORT=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Prepare image name
-        id: vars
-        run: |
-          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          repo=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
-          echo "image=ghcr.io/${owner}/${repo}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -53,20 +71,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ steps.vars.outputs.image }}
-          tags: |
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+      - name: Compute semver tags
+        if: steps.sr.outputs.new_release_published == 'true'
+        id: sv
+        run: |
+          VER="${{ steps.sr.outputs.new_release_version }}"
+          echo "MAJOR=${VER%%.*}" >> $GITHUB_OUTPUT
+          echo "MINOR=${VER%.*}" >> $GITHUB_OUTPUT
 
-      - name: Build and push image
+      - name: Build & push image
+        if: steps.sr.outputs.new_release_published == 'true' && steps.sr.outputs.new_release_channel == ''
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ steps.img.outputs.IMAGE }}:${{ steps.sr.outputs.new_release_version }}
+            ${{ steps.img.outputs.IMAGE }}:${{ steps.sv.outputs.MINOR }}
+            ${{ steps.img.outputs.IMAGE }}:${{ steps.sv.outputs.MAJOR }}
+            ${{ steps.img.outputs.IMAGE }}:latest
+            ${{ steps.img.outputs.IMAGE }}:sha-${{ steps.sha.outputs.SHORT }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.NOW }}
+            org.opencontainers.image.version=${{ steps.sr.outputs.new_release_version }}
+            org.opencontainers.image.title=resume-assistant
+            org.opencontainers.image.description=AI Resume Assistant service
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme


### PR DESCRIPTION
## Summary
- swap release-please for semantic-release so the release job mirrors the working portfolio pipeline
- continue deriving GHCR image metadata and semver tags from the new release outputs
- only install pnpm dependencies when a lockfile exists to keep the job flexible across repos

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68ceefabb9948333915cf76b0ecb9dba