### PR TITLE
fix: specify pnpm version for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Summary
- configure pnpm/action-setup to install pnpm 9 in the release workflow to satisfy action requirements

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68cf341b48448333ae6e0b526e1063b2