### PR TITLE
ci: remove pnpm cache requirement from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
 
       - name: Install dependencies
         if: hashFiles('pnpm-lock.yaml') != ''


### PR DESCRIPTION
## Summary
- remove the pnpm cache configuration from the release workflow so the job no longer errors when no pnpm lockfile is present

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68cf37ad89cc833381e042d413238c84