### PR TITLE
fix: remove unsupported uv frozen flag from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 RUN pip install --no-cache-dir "uv>=0.4,<0.5"
 
 COPY pyproject.toml uv.lock ./
-RUN uv pip install --system --frozen --no-build-isolation -r pyproject.toml
+RUN uv pip install --system --no-build-isolation -r pyproject.toml
 
 COPY app ./app
 COPY main.py ./


### PR DESCRIPTION
## Summary
- remove the unsupported `--frozen` flag from the Docker image dependency installation step

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68cf3cf06bd083339fc647b80c425a1c