### PR TITLE
fix: prevent vector store tie comparison errors

### DIFF
--- a/app/vectorstore.py
+++ b/app/vectorstore.py
@@ -36,14 +36,14 @@ class InMemoryVectorStore:
         if not self._documents:
             return []
         query_embedding = self.embedder.encode([query])[0]
-        scored: list[tuple[float, VectorDocument]] = []
-        for doc, embedding in zip(self._documents, self._embeddings):
+        scored: list[tuple[float, int, VectorDocument]] = []
+        for idx, (doc, embedding) in enumerate(zip(self._documents, self._embeddings)):
             score = cosine_similarity(query_embedding, embedding)
-            heapq.heappush(scored, (score, doc))
+            heapq.heappush(scored, (score, -idx, doc))
             if len(scored) > k:
                 heapq.heappop(scored)
         scored.sort(reverse=True)
-        return [doc for _, doc in scored]
+        return [doc for _, _, doc in scored]
 
 
 VectorStore = InMemoryVectorStore

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -1,0 +1,27 @@
+import pytest
+
+from app.vectorstore import InMemoryVectorStore, VectorDocument
+
+
+class ConstantEmbedder:
+    """Simple embedder returning the same embedding for every input."""
+
+    def encode(self, texts):
+        if isinstance(texts, str):
+            texts = [texts]
+        texts = list(texts)
+        return [[1.0, 0.0] for _ in texts]
+
+
+@pytest.mark.asyncio
+async def test_similarity_search_handles_equal_scores():
+    store = InMemoryVectorStore(embedder=ConstantEmbedder())
+    documents = [
+        VectorDocument(content="doc-1", metadata={"id": 1}),
+        VectorDocument(content="doc-2", metadata={"id": 2}),
+    ]
+    store.add_documents(documents)
+
+    results = await store.similarity_search("any query", k=2)
+
+    assert results == documents


### PR DESCRIPTION
## Summary
- add a deterministic tie-breaker when maintaining the in-memory vector store heap to avoid comparing documents directly
- add a regression test that exercises equal-score documents to confirm the search result order

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d04c68e5d083339237694ff83c8058