### PR TITLE
feat: add agent-managed resume generation workflow

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agent helpers for resume generation."""
+
+from .generation_agent import ResumeGenerationAgent, ResumeGenerationTools
+
+__all__ = ["ResumeGenerationAgent", "ResumeGenerationTools"]

--- a/app/agents/generation_agent.py
+++ b/app/agents/generation_agent.py
@@ -1,0 +1,197 @@
+"""Agent-driven orchestration for resume generation."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Sequence
+
+from ..llm import ResumeLLM, resolve_llm
+from ..models import Resume
+from ..monitoring import ResumeMonitor
+from ..validator import ClaimValidator
+
+CacheLookup = Callable[[str, Dict[str, Any]], Awaitable[Resume | None]]
+CacheStore = Callable[[str, Dict[str, Any], Resume], Awaitable[None]]
+ContextBuilder = Callable[[str, Dict[str, Any]], Awaitable[Dict[str, Any]]]
+ModelSelector = Callable[[str, Dict[str, Any]], str]
+TokenEstimator = Callable[[Resume], int]
+MonitorHook = Callable[[str, int, float, float, bool], Awaitable[None]]
+Timer = Callable[[], float]
+
+
+@dataclass(slots=True)
+class ResumeGenerationTools:
+    """Async hooks used by :class:`ResumeGenerationAgent`."""
+
+    cache_lookup: CacheLookup | None = None
+    cache_store: CacheStore | None = None
+    build_context: ContextBuilder | None = None
+    select_model: ModelSelector | None = None
+    estimate_tokens: TokenEstimator | None = None
+    monitor: MonitorHook | None = None
+    now: Timer = time.perf_counter
+
+
+class ResumeGenerationAgent:
+    """Stateful planner that coordinates resume generation attempts."""
+
+    def __init__(
+        self,
+        llm: ResumeLLM | None = None,
+        validator: ClaimValidator | None = None,
+        monitor: ResumeMonitor | None = None,
+        *,
+        max_retries: int = 2,
+        confidence_threshold: float = 0.8,
+    ) -> None:
+        self.llm = llm or resolve_llm()
+        self.validator = validator or ClaimValidator()
+        self.monitor = monitor or ResumeMonitor()
+        self.max_retries = max(1, max_retries)
+        self.confidence_threshold = confidence_threshold
+        self.plan_steps: Sequence[str] = (
+            "context_retrieval",
+            "draft_generation",
+            "validation",
+            "revision",
+        )
+
+    async def generate(
+        self,
+        job_posting: str,
+        profile: Dict[str, Any],
+        tools: ResumeGenerationTools,
+    ) -> Resume:
+        """Execute the planning loop until validation succeeds or retries are exhausted."""
+
+        monitor_hook = tools.monitor or self.monitor.track_generation
+        cached = await self._check_cache(job_posting, profile, tools, monitor_hook)
+        if cached is not None:
+            return cached
+
+        if tools.build_context is None:
+            raise ValueError("A context builder tool is required for resume generation")
+        if tools.select_model is None:
+            raise ValueError("A model selection tool is required for resume generation")
+
+        base_context = await tools.build_context(job_posting, profile)
+        feedback: Optional[str] = None
+        last_resume: Optional[Resume] = None
+
+        for attempt in range(1, self.max_retries + 1):
+            attempt_context = dict(base_context)
+            if feedback:
+                attempt_context["validator_feedback"] = feedback
+
+            model = tools.select_model(job_posting, profile)
+            start_time = tools.now()
+            resume = await self.llm.generate(model, job_posting, attempt_context)
+            latency = tools.now() - start_time
+
+            resume.metadata["plan"] = list(self.plan_steps)
+            resume.metadata["model"] = model
+            resume.metadata["cached"] = False
+            resume.metadata["latency"] = latency
+            resume.metadata["attempt"] = attempt
+            resume.metadata["attempts"] = attempt
+
+            tokens = self._estimate_tokens(resume, tools)
+            resume.metadata["tokens"] = tokens
+
+            resume = await self.validator.validate(resume, base_context)
+            overall_confidence = float(resume.confidence_scores.get("overall", 0.0))
+            missing_citations = self._missing_citations(resume)
+            validation_passed = (
+                overall_confidence >= self.confidence_threshold and not missing_citations
+            )
+
+            await monitor_hook(model, tokens, latency, overall_confidence, False)
+
+            if validation_passed:
+                resume.metadata["validation_passed"] = True
+                resume.metadata.pop("validator_feedback", None)
+                if tools.cache_store is not None:
+                    await tools.cache_store(job_posting, profile, resume)
+                return resume
+
+            feedback = self._build_feedback(overall_confidence, missing_citations)
+            resume.metadata["validation_passed"] = False
+            resume.metadata["validator_feedback"] = feedback
+            last_resume = resume
+
+        if last_resume is None:  # pragma: no cover - defensive, loop guarantees assignment
+            raise RuntimeError("Generation attempts did not yield a resume")
+        return last_resume
+
+    async def _check_cache(
+        self,
+        job_posting: str,
+        profile: Dict[str, Any],
+        tools: ResumeGenerationTools,
+        monitor_hook: MonitorHook,
+    ) -> Resume | None:
+        if tools.cache_lookup is None:
+            return None
+
+        cached_resume = await tools.cache_lookup(job_posting, profile)
+        if cached_resume is None:
+            return None
+
+        cached_resume.metadata["plan"] = list(self.plan_steps)
+        cached_resume.metadata["cached"] = True
+        cached_resume.metadata.setdefault("latency", 0.0)
+        tokens = self._estimate_tokens(cached_resume, tools)
+        cached_resume.metadata.setdefault("tokens", tokens)
+        cached_resume.metadata.setdefault("attempts", 0)
+
+        if "model" not in cached_resume.metadata and tools.select_model is not None:
+            cached_resume.metadata["model"] = tools.select_model(job_posting, profile)
+
+        model_name = str(cached_resume.metadata.get("model", "unknown"))
+        overall_confidence = float(cached_resume.confidence_scores.get("overall", 0.0))
+        await monitor_hook(
+            model_name,
+            int(cached_resume.metadata.get("tokens", tokens)),
+            float(cached_resume.metadata.get("latency", 0.0)),
+            overall_confidence,
+            True,
+        )
+        return cached_resume
+
+    def _estimate_tokens(self, resume: Resume, tools: ResumeGenerationTools) -> int:
+        if tools.estimate_tokens is not None:
+            try:
+                return int(tools.estimate_tokens(resume))
+            except Exception:  # pragma: no cover - defensive fallback
+                pass
+        return len(resume.to_text().split())
+
+    @staticmethod
+    def _missing_citations(resume: Resume) -> List[str]:
+        missing: List[str] = []
+        provided = resume.citations or {}
+        for experience in resume.experiences:
+            for achievement in experience.achievements:
+                if achievement not in provided:
+                    missing.append(achievement)
+        return missing
+
+    def _build_feedback(self, overall: float, missing_citations: Iterable[str]) -> str:
+        messages: List[str] = []
+        if overall < self.confidence_threshold:
+            messages.append(
+                (
+                    "Overall confidence {:.2f} is below the threshold {:.2f}. "
+                    "Improve grounding or provide additional context."
+                ).format(overall, self.confidence_threshold)
+            )
+        missing = list(missing_citations)
+        if missing:
+            messages.append(
+                "Provide citations or evidence for these achievements: "
+                + ", ".join(missing[:5])
+            )
+        if not messages:
+            messages.append("Refine the resume using validator feedback.")
+        return "\n".join(messages)

--- a/tests/test_generation_agent.py
+++ b/tests/test_generation_agent.py
@@ -1,0 +1,247 @@
+from datetime import date
+from typing import Any, Dict, List
+
+import pytest
+
+from app.agents import ResumeGenerationAgent, ResumeGenerationTools
+from app.models import Experience, Resume
+
+
+class RecordingLLM:
+    def __init__(self, responses: List[Resume]) -> None:
+        self._responses = responses
+        self.calls: List[Dict[str, Any]] = []
+
+    async def generate(self, model: str, job_posting: str, context: Dict[str, Any]) -> Resume:
+        index = len(self.calls)
+        self.calls.append({"model": model, "job_posting": job_posting, "context": context})
+        response = self._responses[index]
+        return response.model_copy(deep=True)
+
+
+class SequenceValidator:
+    def __init__(self, scores: List[float]) -> None:
+        self.scores = scores
+        self.calls = 0
+
+    async def validate(self, resume: Resume, context: Dict[str, Any]) -> Resume:
+        index = min(self.calls, len(self.scores) - 1)
+        resume.confidence_scores["overall"] = self.scores[index]
+        self.calls += 1
+        return resume
+
+
+def build_resume(achievements: List[str], citations: Dict[str, str] | None = None) -> Resume:
+    experience = Experience(
+        company="Acme",
+        role="Engineer",
+        start_date=date(2020, 1, 1),
+        achievements=achievements,
+        location="Remote",
+    )
+    summary = (
+        "Experienced engineer delivering measurable impact on distributed systems while "
+        "aligning achievements with business goals."
+    )
+    return Resume(
+        full_name="Taylor Candidate",
+        email="taylor@example.com",
+        phone="+1 555-0100",
+        location="Remote",
+        summary=summary,
+        experiences=[experience],
+        education=[],
+        skills=["Python", "AWS"],
+        citations=citations or {},
+        confidence_scores={},
+        metadata={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_generates_resume_successfully():
+    resume = build_resume(["Increased reliability by 40% through automation"])
+    resume.citations = {"Increased reliability by 40% through automation": "doc"}
+    llm = RecordingLLM([resume])
+    validator = SequenceValidator([0.92])
+
+    stored: List[Resume] = []
+    metrics: List[Dict[str, Any]] = []
+
+    async def cache_lookup(job: str, profile: Dict[str, Any]) -> Resume | None:
+        return None
+
+    async def cache_store(job: str, profile: Dict[str, Any], generated: Resume) -> None:
+        stored.append(generated)
+
+    async def build_context(job: str, profile: Dict[str, Any]) -> Dict[str, Any]:
+        return {"job_posting": job, "profile": profile}
+
+    def select_model(job: str, profile: Dict[str, Any]) -> str:
+        return "gpt-4o-mini"
+
+    def estimate_tokens(resume: Resume) -> int:
+        return 128
+
+    async def monitor(model: str, tokens: int, latency: float, confidence: float, cache_hit: bool) -> None:
+        metrics.append(
+            {
+                "model": model,
+                "tokens": tokens,
+                "latency": latency,
+                "confidence": confidence,
+                "cache_hit": cache_hit,
+            }
+        )
+
+    tools = ResumeGenerationTools(
+        cache_lookup=cache_lookup,
+        cache_store=cache_store,
+        build_context=build_context,
+        select_model=select_model,
+        estimate_tokens=estimate_tokens,
+        monitor=monitor,
+    )
+
+    agent = ResumeGenerationAgent(
+        llm=llm,
+        validator=validator,
+        max_retries=2,
+        confidence_threshold=0.8,
+    )
+
+    result = await agent.generate("Senior Engineer", {"name": "Taylor"}, tools)
+
+    assert result.metadata["validation_passed"] is True
+    assert result.metadata["attempts"] == 1
+    assert result.metadata["cached"] is False
+    assert stored and stored[0] == result
+    assert metrics and metrics[0]["cache_hit"] is False
+    assert len(llm.calls) == 1
+    assert "plan" in result.metadata
+
+
+@pytest.mark.asyncio
+async def test_agent_retries_with_validator_feedback():
+    resumes = [
+        build_resume(["Improved throughput by 20% via profiling"], {"Improved throughput by 20% via profiling": "doc"}),
+        build_resume(["Improved throughput by 20% via profiling"], {"Improved throughput by 20% via profiling": "doc"}),
+    ]
+    llm = RecordingLLM(resumes)
+    validator = SequenceValidator([0.6, 0.91])
+
+    stored: List[Resume] = []
+
+    async def cache_lookup(job: str, profile: Dict[str, Any]) -> Resume | None:
+        return None
+
+    async def cache_store(job: str, profile: Dict[str, Any], generated: Resume) -> None:
+        stored.append(generated)
+
+    async def build_context(job: str, profile: Dict[str, Any]) -> Dict[str, Any]:
+        return {"job_posting": job, "profile": profile}
+
+    def select_model(job: str, profile: Dict[str, Any]) -> str:
+        return "gpt-4o-mini"
+
+    def estimate_tokens(resume: Resume) -> int:
+        return 256
+
+    metrics: List[Dict[str, Any]] = []
+
+    async def monitor(model: str, tokens: int, latency: float, confidence: float, cache_hit: bool) -> None:
+        metrics.append(
+            {
+                "model": model,
+                "tokens": tokens,
+                "latency": latency,
+                "confidence": confidence,
+                "cache_hit": cache_hit,
+            }
+        )
+
+    tools = ResumeGenerationTools(
+        cache_lookup=cache_lookup,
+        cache_store=cache_store,
+        build_context=build_context,
+        select_model=select_model,
+        estimate_tokens=estimate_tokens,
+        monitor=monitor,
+    )
+
+    agent = ResumeGenerationAgent(
+        llm=llm,
+        validator=validator,
+        max_retries=3,
+        confidence_threshold=0.8,
+    )
+
+    result = await agent.generate("Staff Engineer", {"name": "Taylor"}, tools)
+
+    assert len(llm.calls) == 2
+    second_context = llm.calls[1]["context"]
+    assert "validator_feedback" in second_context
+    assert "Overall confidence" in second_context["validator_feedback"]
+    assert result.metadata["attempts"] == 2
+    assert result.metadata["validation_passed"] is True
+    assert stored and stored[0] == result
+    assert metrics[0]["cache_hit"] is False
+
+
+@pytest.mark.asyncio
+async def test_agent_returns_cached_resume_without_invoking_llm():
+    cached_resume = build_resume(["Cut incident response time by 30% using playbooks"])
+    cached_resume.citations = {"Cut incident response time by 30% using playbooks": "doc"}
+    cached_resume.confidence_scores["overall"] = 0.95
+    cached_resume.metadata = {"model": "gpt-4o-mini", "cached": True}
+    llm = RecordingLLM([cached_resume])
+
+    async def cache_lookup(job: str, profile: Dict[str, Any]) -> Resume | None:
+        return cached_resume.model_copy(deep=True)
+
+    async def cache_store(job: str, profile: Dict[str, Any], generated: Resume) -> None:
+        raise AssertionError("cache_store should not be called on cache hit")
+
+    async def build_context(job: str, profile: Dict[str, Any]) -> Dict[str, Any]:
+        return {"job_posting": job, "profile": profile}
+
+    def select_model(job: str, profile: Dict[str, Any]) -> str:
+        return "gpt-4o-mini"
+
+    def estimate_tokens(resume: Resume) -> int:
+        return 64
+
+    metrics: List[Dict[str, Any]] = []
+
+    async def monitor(model: str, tokens: int, latency: float, confidence: float, cache_hit: bool) -> None:
+        metrics.append(
+            {
+                "model": model,
+                "tokens": tokens,
+                "latency": latency,
+                "confidence": confidence,
+                "cache_hit": cache_hit,
+            }
+        )
+
+    tools = ResumeGenerationTools(
+        cache_lookup=cache_lookup,
+        cache_store=cache_store,
+        build_context=build_context,
+        select_model=select_model,
+        estimate_tokens=estimate_tokens,
+        monitor=monitor,
+    )
+
+    agent = ResumeGenerationAgent(
+        llm=llm,
+        max_retries=1,
+        confidence_threshold=0.8,
+    )
+
+    result = await agent.generate("Engineering Manager", {"name": "Taylor"}, tools)
+
+    assert result.metadata["cached"] is True
+    assert result.metadata["tokens"] == 64
+    assert metrics and metrics[0]["cache_hit"] is True
+    assert len(llm.calls) == 0

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -76,5 +76,19 @@ async def test_generator_uses_cache(profile):
 
     assert llm.calls == 1, "LLM should only be invoked once thanks to caching"
     assert router.calls == 1, "Router should not be consulted again for a cached resume"
+    assert resume_first.metadata.get("cached") is False
+    assert resume_first.metadata.get("validation_passed") is True
+    assert resume_first.metadata.get("plan") == [
+        "context_retrieval",
+        "draft_generation",
+        "validation",
+        "revision",
+    ]
     assert resume_second.metadata.get("cached") is True
+    assert resume_second.metadata.get("plan") == [
+        "context_retrieval",
+        "draft_generation",
+        "validation",
+        "revision",
+    ]
     assert resume_first.confidence_scores.get("overall", 0) >= 0.7


### PR DESCRIPTION
## Summary
- add a `ResumeGenerationAgent` that plans retrieval, drafting, validation, and revision steps while coordinating cache, search, and monitoring hooks
- refactor `ResumeGenerator` to delegate orchestration to the agent and tighten metadata handling across cache hits and retries
- expand the test suite and README to cover agent success, retry, cache paths and document configuration knobs

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a781dff483338aa48e044e40a3e9