### PR TITLE
feat: tighten claim grounding for skills and roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A production-focused resume tailoring service that combines structured LLM outpu
 - **Structured Generation** – All LLM responses are parsed into strict Pydantic models to guarantee ATS compliant formats.
 - **Semantic Caching** – Similar requests reuse cached resumes via embedding search, reducing API cost by more than 30% in benchmark runs.
 - **Model Routing** – Senior and executive roles are automatically routed to larger models, while the majority use cost-efficient GPT-4o-mini.
-- **Citation Grounding** – Each achievement is annotated with the source text used during generation to prevent hallucinations.
+- **Citation Grounding** – Each achievement, skill, and company/role claim is annotated with the source text used during generation to prevent hallucinations.
 - **Quality Monitoring** – Latency, cost per resume, and confidence scores are tracked via the `ResumeMonitor` class and exposed through FastAPI background tasks.
 
 ## Getting Started
@@ -65,6 +65,14 @@ curl -X POST http://localhost:8000/knowledge \
 
 The response summarises how many resumes were processed, the new skills indexed, and a profile snapshot used for subsequent
 generation. Extracted achievements are embedded into the retrieval store so they can be cited during drafting.
+
+### Grounding Requirements
+
+The claim validator now enforces that every skill and company/role listed on a generated resume is supported by the supplied
+context. Ingestion payloads and custom profile overrides must expose `profile.skills` and `profile.experience` (including the
+`company`, `role`, and supporting `achievements`) so validation can attach citations and confidence scores. When the evidence is
+missing, the validator drives the overall confidence to zero, prompting the generation agent to request additional grounding
+before finalising the resume.
 
 ### Generating a Tailored Resume
 

--- a/app/validator.py
+++ b/app/validator.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List
+import re
+from typing import Dict, Iterable, List, Sequence
 
 from .embeddings import SemanticEmbedder
 from .models import Resume
@@ -23,16 +24,68 @@ class ClaimValidator:
             return resume
 
         context_embeddings = self.embedder.encode(context_snippets)
+        semantic_supported = bool(getattr(self.embedder, "_model", None)) and not getattr(
+            self.embedder, "_load_failed", False
+        )
+        snippet_tokens = [self._tokenize(self._normalize(snippet)) for snippet in context_snippets]
+        tokenized_context = list(zip(context_snippets, snippet_tokens))
+
+        profile = self._extract_profile(context)
+        skill_sources = self._collect_skill_sources(context, profile)
+        experience_entries = self._collect_experience_entries(context, profile)
+        company_sources, role_sources = self._collect_experience_sources(experience_entries)
 
         overall_scores: List[float] = []
+
+        def record_score(key: str, raw_score: float, citation: str | None) -> None:
+            score = self._apply_threshold(raw_score)
+            resume.confidence_scores[key] = score
+            if citation and score > 0:
+                resume.citations.setdefault(key, citation)
+            overall_scores.append(score)
+
         for experience in resume.experiences:
             for achievement in experience.achievements:
                 achievement_embedding = self.embedder.encode([achievement])[0]
-                similarity, citation = self._max_similarity(achievement_embedding, context_embeddings, context_snippets)
-                resume.confidence_scores[achievement] = similarity
-                if citation:
-                    resume.citations.setdefault(achievement, citation)
-                overall_scores.append(similarity)
+                similarity, citation = self._max_similarity(
+                    achievement_embedding, context_embeddings, context_snippets
+                )
+                record_score(achievement, similarity, citation)
+
+        for skill in resume.skills:
+            score, citation = self._evaluate_claim(
+                claim=skill,
+                direct_sources=skill_sources,
+                context_embeddings=context_embeddings,
+                context_snippets=context_snippets,
+                tokenized_context=tokenized_context,
+                allow_semantic=semantic_supported,
+            )
+            record_score(f"skill:{skill}", score, citation)
+
+        for experience in resume.experiences:
+            company_key = f"experience.company:{experience.company}"
+            company_score, company_citation = self._evaluate_claim(
+                claim=experience.company,
+                direct_sources=company_sources,
+                context_embeddings=context_embeddings,
+                context_snippets=context_snippets,
+                tokenized_context=tokenized_context,
+                allow_semantic=semantic_supported,
+            )
+            record_score(company_key, company_score, company_citation)
+
+            role_claim = f"{experience.role} at {experience.company}" if experience.company else experience.role
+            role_key = f"experience.role:{experience.role} at {experience.company}"
+            role_score, role_citation = self._evaluate_claim(
+                claim=role_claim,
+                direct_sources=role_sources,
+                context_embeddings=context_embeddings,
+                context_snippets=context_snippets,
+                tokenized_context=tokenized_context,
+                allow_semantic=semantic_supported,
+            )
+            record_score(role_key, role_score, role_citation)
 
         if overall_scores:
             resume.confidence_scores["overall"] = min(overall_scores)
@@ -56,6 +109,107 @@ class ClaimValidator:
         if isinstance(value, list):
             return [snippet for item in value for snippet in self._stringify(item)]
         return [str(value)]
+
+    def _extract_profile(self, context: Dict[str, object]) -> Dict[str, object]:
+        profile = context.get("profile")
+        if isinstance(profile, dict):
+            return profile
+        return {}
+
+    def _collect_skill_sources(
+        self, context: Dict[str, object], profile: Dict[str, object]
+    ) -> List[tuple[str, str]]:
+        sources: List[tuple[str, str]] = []
+        for container in (context.get("skills"), profile.get("skills")):
+            for value in self._iter_strings(container):
+                normalized = self._normalize(value)
+                if normalized:
+                    sources.append((normalized, value))
+        return sources
+
+    def _collect_experience_entries(
+        self, context: Dict[str, object], profile: Dict[str, object]
+    ) -> List[Dict[str, object]]:
+        entries: List[Dict[str, object]] = []
+        for container in (context.get("experience"), profile.get("experience")):
+            if isinstance(container, list):
+                for value in container:
+                    if isinstance(value, dict):
+                        entries.append(value)
+        return entries
+
+    def _collect_experience_sources(
+        self, entries: Sequence[Dict[str, object]]
+    ) -> tuple[List[tuple[str, str]], List[tuple[str, str]]]:
+        company_sources: List[tuple[str, str]] = []
+        role_sources: List[tuple[str, str]] = []
+        for entry in entries:
+            company = entry.get("company")
+            role = entry.get("role")
+            if isinstance(company, str) and company.strip():
+                normalized_company = self._normalize(company)
+                if normalized_company:
+                    company_sources.append((normalized_company, company))
+            if isinstance(role, str) and role.strip():
+                if isinstance(company, str) and company.strip():
+                    citation = f"{role} at {company}"
+                else:
+                    citation = role
+                normalized_role = self._normalize(citation)
+                if normalized_role:
+                    role_sources.append((normalized_role, citation))
+        return company_sources, role_sources
+
+    def _evaluate_claim(
+        self,
+        claim: str,
+        *,
+        direct_sources: Sequence[tuple[str, str]],
+        context_embeddings: List[List[float]],
+        context_snippets: List[str],
+        tokenized_context: Sequence[tuple[str, set[str]]],
+        allow_semantic: bool,
+    ) -> tuple[float, str | None]:
+        normalized_claim = self._normalize(claim)
+        if not normalized_claim:
+            return 0.0, None
+
+        for source_value, citation in direct_sources:
+            if normalized_claim == source_value:
+                return 1.0, citation
+
+        claim_tokens = self._tokenize(normalized_claim)
+        for snippet, tokens in tokenized_context:
+            if claim_tokens and (claim_tokens <= tokens or tokens <= claim_tokens):
+                return 1.0, snippet
+
+        if not allow_semantic:
+            return 0.0, None
+
+        claim_embedding = self.embedder.encode([claim])[0]
+        return self._max_similarity(claim_embedding, context_embeddings, context_snippets)
+
+    def _apply_threshold(self, score: float) -> float:
+        if score < self.threshold:
+            return 0.0
+        return score
+
+    def _iter_strings(self, value: object) -> Iterable[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value] if value.strip() else []
+        if isinstance(value, (list, tuple, set)):
+            return [item for item in value if isinstance(item, str) and item.strip()]
+        return []
+
+    def _normalize(self, value: str) -> str:
+        return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+
+    def _tokenize(self, normalized_value: str) -> set[str]:
+        if not normalized_value:
+            return set()
+        return {token for token in normalized_value.split(" ") if token}
 
     @staticmethod
     def _max_similarity(

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,104 @@
+from datetime import date
+
+import pytest
+
+from app.embeddings import SemanticEmbedder
+from app.models import Experience, Resume
+from app.validator import ClaimValidator
+
+
+def _build_resume(
+    *,
+    company: str,
+    role: str,
+    achievement: str,
+    skills: list[str],
+) -> Resume:
+    return Resume(
+        full_name="Taylor Candidate",
+        email="taylor@example.com",
+        phone="+1 555-0100",
+        location="Remote",
+        summary=(
+            "Seasoned professional delivering measurable improvements across "
+            "large-scale engineering programs while aligning outcomes to business needs."
+        ),
+        experiences=[
+            Experience(
+                company=company,
+                role=role,
+                start_date=date(2020, 1, 1),
+                achievements=[achievement],
+            )
+        ],
+        skills=skills,
+    )
+
+
+@pytest.mark.asyncio
+async def test_validator_scores_profile_alignment() -> None:
+    resume = _build_resume(
+        company="Acme Corporation",
+        role="Senior Engineer",
+        achievement="Improved system reliability by 30% through automation",
+        skills=["Python", "AWS"],
+    )
+    context = {
+        "profile": {
+            "skills": ["Python", "AWS"],
+            "experience": [
+                {
+                    "company": "Acme Corporation",
+                    "role": "Senior Engineer",
+                    "achievements": ["Improved system reliability by 30% through automation"],
+                }
+            ],
+        }
+    }
+
+    validator = ClaimValidator(SemanticEmbedder())
+    validated = await validator.validate(resume, context)
+
+    assert validated.confidence_scores["skill:Python"] == pytest.approx(1.0)
+    assert validated.confidence_scores["experience.company:Acme Corporation"] == pytest.approx(1.0)
+    assert (
+        validated.confidence_scores["experience.role:Senior Engineer at Acme Corporation"]
+        == pytest.approx(1.0)
+    )
+    assert validated.confidence_scores["overall"] == pytest.approx(1.0)
+    assert validated.citations["skill:Python"] == "Python"
+    assert (
+        validated.citations["experience.role:Senior Engineer at Acme Corporation"]
+        == "Senior Engineer at Acme Corporation"
+    )
+
+
+@pytest.mark.asyncio
+async def test_validator_flags_hallucinated_skill_and_role() -> None:
+    resume = _build_resume(
+        company="Initech",
+        role="Platform Lead",
+        achievement="Reduced deployment failures by 40% via new CI pipelines",
+        skills=["GraphQL"],
+    )
+    context = {
+        "profile": {
+            "skills": ["Python"],
+            "experience": [
+                {
+                    "company": "Acme Corporation",
+                    "role": "Senior Engineer",
+                    "achievements": ["Improved system reliability by 30% through automation"],
+                }
+            ],
+        }
+    }
+
+    validator = ClaimValidator(SemanticEmbedder())
+    validated = await validator.validate(resume, context)
+
+    assert validated.confidence_scores["skill:GraphQL"] == 0.0
+    assert validated.confidence_scores["experience.company:Initech"] == 0.0
+    assert validated.confidence_scores["experience.role:Platform Lead at Initech"] == 0.0
+    assert validated.confidence_scores["overall"] == 0.0
+    assert "skill:GraphQL" not in validated.citations


### PR DESCRIPTION
## Summary
- enforce the claim validator to cross-check skills and company/role details against the supplied profile context and lower confidence when evidence is missing
- add validator-focused unit tests covering grounded and hallucinated skill/experience claims
- document the stricter grounding requirements so ingestion payloads expose the fields used during validation

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a787db6083339915e23dcd1575ae