### PR TITLE
fix: skip corrupt cache entries

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
 from .embeddings import SemanticEmbedder
 from .models import Resume
 from .utils import cosine_similarity
+
+logger = logging.getLogger(__name__)
 
 
 class SemanticCache:
@@ -47,7 +50,11 @@ class SemanticCache:
                     cached_raw = cached_raw.decode("utf-8")
                 if not cached_raw:
                     continue
-                cached = json.loads(cached_raw)
+                try:
+                    cached = json.loads(cached_raw)
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Skipping corrupt cache entry for key %s", key)
+                    continue
                 cached_embedding = cached.get("embedding")
                 if not cached_embedding:
                     continue

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -34,3 +34,39 @@ async def test_semantic_cache_roundtrip():
     assert cached is not None
     assert cached.full_name == resume.full_name
     assert cached.metadata.get("cached") is True
+
+
+@pytest.mark.asyncio
+async def test_semantic_cache_skips_corrupt_entries():
+    redis_client = InMemoryRedis()
+    cache = SemanticCache(redis_client)
+    resume = Resume(
+        full_name="Taylor Candidate",
+        email="taylor@example.com",
+        phone="+1 555-0100",
+        location="Remote",
+        summary="""Seasoned engineer delivering 40% deployment gains and cost savings.""",
+        experiences=[
+            Experience(
+                company="Acme",
+                role="Engineer",
+                start_date=date(2020, 1, 1),
+                achievements=["Improved deployment speed by 40%"],
+            )
+        ],
+        education=[],
+        skills=["Python"],
+    )
+
+    await cache.set(
+        "Software Engineer",
+        {"full_name": "Taylor Candidate"},
+        resume,
+    )
+    await redis_client.setex("resume:!corrupt", 60, "{not json")
+
+    cached = await cache.get("Software Engineer", {"full_name": "Taylor Candidate"})
+
+    assert cached is not None
+    assert cached.full_name == resume.full_name
+    assert cached.metadata.get("cached") is True


### PR DESCRIPTION
## Summary
- skip cache entries that fail JSON decoding and log the skipped key for visibility
- add a unit test to ensure corrupt cache entries do not block valid resume retrieval

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d3216859008333ae50caa02b0b2e07