### PR TITLE
feat: compute experience duration from dates

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Dict
+from datetime import date, datetime
+from typing import Dict, Optional
 
 
 @dataclass(frozen=True)
@@ -73,6 +74,10 @@ class ModelRouter:
                 if isinstance(entry_years, (int, float)):
                     total += float(entry_years)
                     continue
+                duration = self._years_from_dates(entry)
+                if duration is not None:
+                    total += duration
+                    continue
                 # fallback to parse text
                 description = " ".join(str(value) for value in entry.values())
                 total += self._years_from_text(description)
@@ -82,3 +87,43 @@ class ModelRouter:
     def _years_from_text(text: str) -> float:
         matches = re.findall(r"(\d+(?:\.\d+)?)\s*(?:\+\s*)?(?:years|yrs)", text, flags=re.I)
         return sum(float(match) for match in matches)
+
+    @staticmethod
+    def _coerce_date(value: object) -> Optional[date]:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return None
+            lowered = text.lower()
+            if lowered in {"present", "current", "now"}:
+                return date.today()
+            try:
+                return date.fromisoformat(text)
+            except ValueError:
+                try:
+                    return datetime.fromisoformat(text).date()
+                except ValueError:
+                    if re.fullmatch(r"\d{4}-\d{2}", text):
+                        try:
+                            return date.fromisoformat(f"{text}-01")
+                        except ValueError:
+                            return None
+                    return None
+        return None
+
+    def _years_from_dates(self, entry: dict) -> Optional[float]:
+        start_date = self._coerce_date(entry.get("start_date"))
+        end_date = self._coerce_date(entry.get("end_date"))
+        if start_date is None:
+            return None
+        if end_date is None:
+            end_date = date.today()
+        if end_date < start_date:
+            return None
+        return (end_date - start_date).days / 365.25

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from app.router import ModelRouter
 
 
@@ -18,4 +20,39 @@ def test_executive_routing_requires_years_and_keywords():
     router = ModelRouter()
     profile = {"years_experience": 15}
     model = router.select_model("Chief Technology Officer", profile)
+    assert model == "gpt-4o"
+
+
+def test_senior_routing_uses_dated_experience():
+    router = ModelRouter()
+    profile = {
+        "experience": [
+            {
+                "company": "Example Corp",
+                "start_date": "2010-01-01",
+                "end_date": "2019-01-01",
+            }
+        ]
+    }
+    model = router.select_model("Senior Software Engineer", profile)
+    assert model == "gpt-4o"
+
+
+def test_executive_routing_uses_dated_experience():
+    router = ModelRouter()
+    profile = {
+        "experiences": [
+            {
+                "company": "Example Corp",
+                "start_date": date(2005, 1, 1),
+                "end_date": date(2015, 1, 1),
+            },
+            {
+                "company": "Another Corp",
+                "start_date": "2015-01-01",
+                "end_date": "2022-01-01",
+            },
+        ]
+    }
+    model = router.select_model("Chief Information Officer", profile)
     assert model == "gpt-4o"


### PR DESCRIPTION
## Summary
- derive experience totals from structured start and end dates before falling back to keyword heuristics
- exercise routing with dated experiences to confirm senior and executive thresholds promote higher-tier models

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d32157594c8333b545c39fe8a75e5f