### PR TITLE
chore: export openapi schema during releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: uv sync --locked
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -34,6 +42,9 @@ jobs:
       - name: Install dependencies
         if: hashFiles('pnpm-lock.yaml') != ''
         run: pnpm install --frozen-lockfile
+
+      - name: Export OpenAPI schema
+        run: uv run python scripts/export_openapi.py
 
       - name: Semantic Release
         id: sr

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,7 +12,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md"],
+        "assets": ["CHANGELOG.md", "openapi.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
       }
     ],

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,601 @@
+{
+  "components": {
+    "schemas": {
+      "Body_ingest_knowledge_knowledge_post": {
+        "properties": {
+          "notes": {
+            "default": "",
+            "title": "Notes",
+            "type": "string"
+          },
+          "resumes": {
+            "description": "Resume files to ingest",
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Resumes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "resumes"
+        ],
+        "title": "Body_ingest_knowledge_knowledge_post",
+        "type": "object"
+      },
+      "ChatMessage": {
+        "properties": {
+          "content": {
+            "minLength": 1,
+            "title": "Content",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "role": {
+            "enum": [
+              "system",
+              "user",
+              "assistant"
+            ],
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "ChatMessage",
+        "type": "object"
+      },
+      "ChatRequest": {
+        "properties": {
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "minItems": 1,
+            "title": "Messages",
+            "type": "array"
+          },
+          "session": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session"
+          }
+        },
+        "required": [
+          "messages"
+        ],
+        "title": "ChatRequest",
+        "type": "object"
+      },
+      "ChatResponse": {
+        "properties": {
+          "reply": {
+            "$ref": "#/components/schemas/ChatMessage"
+          },
+          "session": {
+            "title": "Session",
+            "type": "object"
+          }
+        },
+        "required": [
+          "reply",
+          "session"
+        ],
+        "title": "ChatResponse",
+        "type": "object"
+      },
+      "Education": {
+        "description": "Education entry for the resume.",
+        "properties": {
+          "degree": {
+            "maxLength": 150,
+            "minLength": 1,
+            "title": "Degree",
+            "type": "string"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "gpa": {
+            "anyOf": [
+              {
+                "maxLength": 10,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gpa"
+          },
+          "highlights": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 5,
+            "title": "Highlights",
+            "type": "array"
+          },
+          "institution": {
+            "maxLength": 150,
+            "minLength": 1,
+            "title": "Institution",
+            "type": "string"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date"
+          }
+        },
+        "required": [
+          "institution",
+          "degree"
+        ],
+        "title": "Education",
+        "type": "object"
+      },
+      "Experience": {
+        "description": "Professional experience entry for a resume.",
+        "properties": {
+          "achievements": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 8,
+            "minItems": 1,
+            "title": "Achievements",
+            "type": "array"
+          },
+          "company": {
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Company",
+            "type": "string"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "role": {
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Role",
+            "type": "string"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "company",
+          "role",
+          "start_date",
+          "achievements"
+        ],
+        "title": "Experience",
+        "type": "object"
+      },
+      "GenerateRequest": {
+        "properties": {
+          "job_posting": {
+            "minLength": 10,
+            "title": "Job Posting",
+            "type": "string"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile"
+          }
+        },
+        "required": [
+          "job_posting"
+        ],
+        "title": "GenerateRequest",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "Resume": {
+        "description": "Strict schema for ATS compatible resume generation.",
+        "properties": {
+          "citations": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Citations",
+            "type": "object"
+          },
+          "confidence_scores": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Confidence Scores",
+            "type": "object"
+          },
+          "education": {
+            "items": {
+              "$ref": "#/components/schemas/Education"
+            },
+            "maxItems": 5,
+            "title": "Education",
+            "type": "array"
+          },
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "experiences": {
+            "items": {
+              "$ref": "#/components/schemas/Experience"
+            },
+            "maxItems": 10,
+            "minItems": 1,
+            "title": "Experiences",
+            "type": "array"
+          },
+          "full_name": {
+            "maxLength": 120,
+            "minLength": 3,
+            "title": "Full Name",
+            "type": "string"
+          },
+          "location": {
+            "maxLength": 120,
+            "minLength": 2,
+            "title": "Location",
+            "type": "string"
+          },
+          "metadata": {
+            "title": "Metadata",
+            "type": "object"
+          },
+          "phone": {
+            "maxLength": 30,
+            "pattern": "^[\\+\\d\\s\\-\\(\\)]+$",
+            "title": "Phone",
+            "type": "string"
+          },
+          "skills": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20,
+            "title": "Skills",
+            "type": "array"
+          },
+          "summary": {
+            "maxLength": 500,
+            "minLength": 50,
+            "title": "Summary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "full_name",
+          "email",
+          "phone",
+          "location",
+          "summary",
+          "experiences"
+        ],
+        "title": "Resume",
+        "type": "object"
+      },
+      "ValidateRequest": {
+        "properties": {
+          "resume_text": {
+            "minLength": 50,
+            "title": "Resume Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "resume_text"
+        ],
+        "title": "ValidateRequest",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "AI Resume Service",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/chat": {
+      "post": {
+        "description": "Return a grounded chat response using the resume generator.",
+        "operationId": "chat_turn_chat_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Chat Turn"
+      }
+    },
+    "/generate": {
+      "post": {
+        "description": "Generate a resume tailored to a job posting.",
+        "operationId": "generate_resume_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resume"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Generate Resume"
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthcheck_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Healthcheck Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Healthcheck"
+      }
+    },
+    "/knowledge": {
+      "post": {
+        "description": "Ingest uploaded resumes into the knowledge store and vector index.",
+        "operationId": "ingest_knowledge_knowledge_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ingest_knowledge_knowledge_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Ingest Knowledge Knowledge Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ingest Knowledge"
+      }
+    },
+    "/validate": {
+      "post": {
+        "description": "Return heuristic quality scores for a resume.",
+        "operationId": "validate_resume_validate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "number"
+                  },
+                  "title": "Response Validate Resume Validate Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Validate Resume"
+      }
+    }
+  }
+}

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,36 @@
+"""Export the OpenAPI schema for the FastAPI application."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from fastapi.openapi.utils import get_openapi
+
+from app import create_app
+
+
+def export_schema(destination: Path) -> None:
+    """Generate the OpenAPI schema and persist it to ``destination``."""
+    app = create_app()
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+    destination.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    export_schema(REPO_ROOT / "openapi.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable script for exporting the FastAPI OpenAPI schema to openapi.json
- run the export in the release workflow after syncing Python dependencies
- include the generated schema in semantic-release git assets so it is committed on releases

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app
- GH_TOKEN=faketoken npx --yes -p semantic-release -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/github -p @semantic-release/commit-analyzer -p @semantic-release/release-notes-generator semantic-release --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d352e9e42c8333b3e17e759c27d2b1