### PR TITLE
fix: correct docker cmd syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,4 @@ EXPOSE 8030
 
 ENV LANGGRAPH_CONFIG=/app/langgraph.json
 
-CMD [
-  "langgraph",
-  "server",
-  "start",
-  "--config",
-  "/app/langgraph.json",
-  "--host",
-  "0.0.0.0",
-  "--port",
-  "8030"
-]
+CMD ["langgraph", "server", "start", "--config", "/app/langgraph.json", "--host", "0.0.0.0", "--port", "8030"]


### PR DESCRIPTION
## Summary
- fix the Dockerfile CMD instruction by using the correct JSON-array form so the build parses

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d379297570833388ca56c89372a448