### PR TITLE
Add live OpenAI integration tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,21 @@ jobs:
         run: uv sync --extra dev --locked
       - name: Run pytest
         run: uv run pytest
+
+  live-openai-tests:
+    name: OpenAI integration tests
+    runs-on: ubuntu-latest
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: uv sync --extra dev --locked
+      - name: Run live OpenAI tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: uv run pytest tests/test_llm_live.py

--- a/tests/test_llm_live.py
+++ b/tests/test_llm_live.py
@@ -1,0 +1,74 @@
+"""Live integration tests that exercise the OpenAI-backed LLM."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+import pytest
+
+from app.tools.llm import OpenAIResumeLLM
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY must be set to run live OpenAI tests",
+)
+
+
+def _assert_non_empty_str(value: str) -> None:
+    assert isinstance(value, str)
+    assert value.strip(), "expected non-empty string"
+
+
+def test_openai_resume_llm_end_to_end_live() -> None:
+    """Ensure the OpenAI LLM can plan, draft, critique, and review a resume."""
+
+    llm = OpenAIResumeLLM(model="gpt-4o-mini", temperature=0)
+
+    profile: Dict[str, object] = {
+        "name": "Jordan Rivera",
+        "headline": "Full-stack engineer transitioning into ML ops",
+        "skills": ["python", "docker", "ml ops"],
+        "experience": [
+            {
+                "role": "Software Engineer",
+                "company": "Acme Corp",
+                "highlights": ["Built CI/CD pipelines", "Led migration to containers"],
+            }
+        ],
+    }
+    knowledge_hits: List[Dict[str, object]] = [
+        {
+            "title": "Recent achievements",
+            "content": "Implemented observability tooling and automated deployment scripts.",
+        }
+    ]
+
+    plan = llm.plan_resume(profile, knowledge_hits)
+    _assert_non_empty_str(plan["summary"])
+    assert plan["skills"], "expected at least one skill"
+    assert all(isinstance(skill, str) and skill for skill in plan["skills"])
+    assert plan["experience"], "expected experience entries"
+    assert all(isinstance(item, dict) for item in plan["experience"])
+
+    resume_markdown = llm.draft_resume(plan, profile, knowledge_hits)
+    _assert_non_empty_str(resume_markdown)
+    assert "Summary" in resume_markdown
+    assert "Skills" in resume_markdown
+    assert "Experience" in resume_markdown
+
+    critique = llm.critique_resume(resume_markdown, profile)
+    assert set(critique.keys()) == {"needs_revision", "issues"}
+    assert isinstance(critique["needs_revision"], bool)
+    assert isinstance(critique["issues"], list)
+
+    policy = {
+        "rules": [
+            "Reject resumes containing disallowed phrases like 'forbidden'.",
+            "Approve resumes that present professional experience without sensitive data.",
+        ]
+    }
+    compliance = llm.compliance_review(resume_markdown, policy)
+    assert compliance["status"] in {"approved", "rejected"}
+    assert isinstance(compliance["violations"], list)
+


### PR DESCRIPTION
## Summary
- add a pytest integration test that exercises the OpenAI-backed resume workflow when an API key is present
- extend the CI workflow with a gated job that runs the live test suite using the OPENAI_API_KEY secret

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d42655b0c88333beb411646bee0ed7