### PR TITLE
fix(ci): guard live OpenAI tests on secret presence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - tests
     env:
       LIVE_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-    if: ${{ env.LIVE_OPENAI_API_KEY != '' }}
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- fix the CI live OpenAI job condition to reference the secrets context directly

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d4448b67988333a287967db2cf8100