### PR TITLE
ci: gate openai job on workflow env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
 permissions:
   contents: read
 
@@ -68,9 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tests
-    env:
-      LIVE_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    if: ${{ env.OPENAI_API_KEY != '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -81,6 +82,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --locked
       - name: Run live OpenAI tests
-        env:
-          OPENAI_API_KEY: ${{ env.LIVE_OPENAI_API_KEY }}
         run: uv run pytest tests/test_llm_live.py


### PR DESCRIPTION
## Summary
- expose `OPENAI_API_KEY` at the workflow level so it can be used for conditions
- guard the live OpenAI job with the workflow env instead of referencing secrets directly

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d45ae2a8b4833399c1c58c43902128