### PR TITLE
ci: cache uv deps and gate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
   lint:
     name: Ruff lint
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON_VERSION: '3.12'
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -26,6 +28,15 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ${{ env.HOME }}/.cache/uv
+          key: ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-
       - name: Install dependencies
         run: uv sync --extra dev --locked
       - name: Run Ruff
@@ -34,6 +45,8 @@ jobs:
   type-check:
     name: Mypy type check
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON_VERSION: '3.12'
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -41,6 +54,15 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ${{ env.HOME }}/.cache/uv
+          key: ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-
       - name: Install dependencies
         run: uv sync --extra dev --locked
       - name: Run mypy
@@ -52,6 +74,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.12', '3.13']
+    env:
+      UV_PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -59,6 +83,15 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ${{ env.HOME }}/.cache/uv
+          key: ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-
       - name: Install dependencies
         run: uv sync --extra dev --locked
       - name: Run pytest
@@ -70,6 +103,8 @@ jobs:
     needs:
       - tests
     if: ${{ env.OPENAI_API_KEY != '' }}
+    env:
+      UV_PYTHON_VERSION: '3.12'
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -77,6 +112,15 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ${{ env.HOME }}/.cache/uv
+          key: ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-
       - name: Install dependencies
         run: uv sync --extra dev --locked
       - name: Run live OpenAI tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: release
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
 permissions:
   contents: write
@@ -13,8 +18,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  release:
+  quality-gate:
+    name: Release quality gate
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON_VERSION: '3.12'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -23,13 +31,38 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
+          python-version: '3.12'
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ${{ env.HOME }}/.cache/uv
+          key: ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-
 
       - name: Install dependencies
         run: uv sync --extra dev --locked
 
-      - name: Run tests
+      - name: Run Ruff
+        run: uv run --extra dev ruff check
+
+      - name: Run mypy
+        run: uv run --extra dev mypy app
+
+      - name: Run pytest
         run: uv run pytest
+
+  release:
+    runs-on: ubuntu-latest
+    needs: quality-gate
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Summary
- cache the uv virtualenv and package cache in CI to avoid repeated syncs across jobs
- add a release workflow quality gate that re-runs lint, mypy, and pytest with caching before publishing
- ensure the release quality gate also runs on pull requests targeting main so open PRs exercise the release checks

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d45d8212e4833390e2e9cf0e824ef2