### PR TITLE
ci: harden workflow secret scope and permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
 
-env:
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-
 permissions:
   contents: read
 
@@ -102,9 +99,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tests
-    if: ${{ env.OPENAI_API_KEY != '' }}
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
     env:
       UV_PYTHON_VERSION: '3.12'
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,6 @@ name: release
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-env:
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-
-permissions:
-  contents: write
-  packages: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -59,6 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality-gate
     if: github.event_name == 'push'
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary
- remove the workflow-wide OPENAI_API_KEY export in CI and scope the secret to the integration job
- drop pull_request runs from the release workflow and move elevated permissions to the release job

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d4605e8b0c83338404a57641cc9b0b