### PR TITLE
feat: add OpenAPI schema generation workflow

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,44 @@
+name: Generate OpenAPI schema
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  UV_PYTHON_VERSION: '3.12'
+
+jobs:
+  openapi:
+    name: Build OpenAPI schema
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ env.UV_PYTHON_VERSION }}
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ${{ env.HOME }}/.cache/uv
+          key: ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ env.UV_PYTHON_VERSION }}-
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Generate OpenAPI schema
+        run: uv run python scripts/generate_openapi.py --output openapi-schema.json
+      - name: Upload schema artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-schema
+          path: openapi-schema.json
+          if-no-files-found: error

--- a/openapi-schema.json
+++ b/openapi-schema.json
@@ -1,0 +1,450 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Resume Assistant API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/workflows/resume": {
+      "post": {
+        "summary": "Start Resume Workflow",
+        "operationId": "start_resume_workflow_workflows_resume_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartWorkflowRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartWorkflowResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{workflow_id}": {
+      "get": {
+        "summary": "Get Resume State",
+        "operationId": "get_resume_state_workflows__workflow_id__get",
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowStateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{workflow_id}/approval": {
+      "post": {
+        "summary": "Submit Human Approval",
+        "operationId": "submit_human_approval_workflows__workflow_id__approval_post",
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{workflow_id}/result": {
+      "get": {
+        "summary": "Get Workflow Result",
+        "operationId": "get_workflow_result_workflows__workflow_id__result_get",
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowResultResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApprovalRequest": {
+        "properties": {
+          "approved": {
+            "type": "boolean",
+            "title": "Approved"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "approved"
+        ],
+        "title": "ApprovalRequest"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ResumeMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "human",
+              "assistant",
+              "system"
+            ],
+            "title": "Role"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          }
+        },
+        "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "ResumeMessage",
+        "description": "Normalized chat message stored inside the workflow state."
+      },
+      "ResumeWorkflowState": {
+        "properties": {
+          "task": {
+            "type": "string",
+            "enum": [
+              "ingest",
+              "draft",
+              "revise",
+              "resume_pipeline",
+              "compliance_only",
+              "publish"
+            ],
+            "title": "Task"
+          },
+          "stage": {
+            "type": "string",
+            "enum": [
+              "route",
+              "ingestion",
+              "drafting",
+              "critique",
+              "revision",
+              "compliance",
+              "publishing",
+              "done"
+            ],
+            "title": "Stage",
+            "default": "route"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "in_progress",
+              "complete",
+              "error"
+            ],
+            "title": "Status",
+            "default": "pending"
+          },
+          "request_id": {
+            "type": "string",
+            "title": "Request Id"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ResumeMessage"
+            },
+            "type": "array",
+            "title": "Messages"
+          },
+          "artifacts": {
+            "type": "object",
+            "title": "Artifacts"
+          },
+          "audit_trail": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Audit Trail"
+          },
+          "metrics": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Metrics"
+          },
+          "flags": {
+            "type": "object",
+            "title": "Flags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "task",
+          "request_id"
+        ],
+        "title": "ResumeWorkflowState",
+        "description": "Serializable workflow state tracked across Temporal executions."
+      },
+      "StartWorkflowRequest": {
+        "properties": {
+          "task": {
+            "type": "string",
+            "enum": [
+              "ingest",
+              "draft",
+              "revise",
+              "resume_pipeline",
+              "compliance_only",
+              "publish"
+            ],
+            "title": "Task",
+            "default": "resume_pipeline"
+          },
+          "artifacts": {
+            "type": "object",
+            "title": "Artifacts"
+          },
+          "flags": {
+            "type": "object",
+            "title": "Flags"
+          },
+          "request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Id"
+          }
+        },
+        "type": "object",
+        "title": "StartWorkflowRequest"
+      },
+      "StartWorkflowResponse": {
+        "properties": {
+          "workflow_id": {
+            "type": "string",
+            "title": "Workflow Id"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "workflow_id",
+          "run_id"
+        ],
+        "title": "StartWorkflowResponse"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WorkflowResultResponse": {
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/ResumeWorkflowState"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "title": "WorkflowResultResponse"
+      },
+      "WorkflowStateResponse": {
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/ResumeWorkflowState"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "title": "WorkflowStateResponse"
+      }
+    }
+  }
+}

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,44 @@
+"""Utility to export the FastAPI OpenAPI schema to disk."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from fastapi.encoders import jsonable_encoder
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.api import app  # noqa: E402
+
+
+def export_openapi_schema(output_path: Path) -> None:
+    """Generate the OpenAPI schema for the FastAPI app and persist it."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    schema = app.openapi()
+    encoded_schema = jsonable_encoder(schema)
+    output_path.write_text(json.dumps(encoded_schema, indent=2), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate the OpenAPI schema file")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("openapi-schema.json"),
+        help="Path to write the generated schema to",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    export_openapi_schema(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable `scripts/generate_openapi.py` helper to export the FastAPI schema
- introduce a GitHub Actions workflow to build and publish the OpenAPI schema as an artifact
- check the generated `openapi-schema.json` into the repository for downstream consumption

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d461ef9c908333877a44e328bdaf45