### PR TITLE
feat: add API health check

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -39,6 +39,10 @@ class ApprovalRequest(BaseModel):
     notes: Optional[str] = None
 
 
+class HealthResponse(BaseModel):
+    status: str = "ok"
+
+
 class WorkflowStateResponse(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -94,6 +98,11 @@ async def start_resume_workflow(
         id_reuse_policy=WorkflowIDReusePolicy.TERMINATE_IF_RUNNING,
     )
     return StartWorkflowResponse(workflow_id=handle.id, run_id=handle.run_id)
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health_check() -> HealthResponse:
+    return HealthResponse()
 
 
 @app.get("/workflows/{workflow_id}", response_model=WorkflowStateResponse)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,6 +68,14 @@ async def test_start_workflow(api_client):
 
 
 @pytest.mark.asyncio
+async def test_health_check(api_client):
+    client, _dummy = api_client
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
 async def test_get_workflow_state(api_client):
     client, _dummy = api_client
     response = await client.get("/workflows/req-123")


### PR DESCRIPTION
## Summary
- add a dedicated `/health` FastAPI route returning an ok status payload
- expose a HealthResponse schema to keep output consistent with other endpoints
- cover the new endpoint with an async API test

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d46561faa88333b4be1541c9335ce3