### PR TITLE
fix: guard live OpenAI tests with secrets context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tests
-    if: ${{ env.OPENAI_API_KEY != '' }}
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
     env:
       UV_PYTHON_VERSION: '3.12'
-      OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- gate the live OpenAI test job directly on the OPENAI_API_KEY secret
- pass the OPENAI_API_KEY secret into the job environment without relying on the env context

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d467cf27d48333b1d934322de9de5f