### PR TITLE
chore: push OpenAPI schema updates from workflow

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   UV_PYTHON_VERSION: '3.12'
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -42,3 +44,13 @@ jobs:
           name: openapi-schema
           path: openapi-schema.json
           if-no-files-found: error
+      - name: Commit and push schema changes
+        run: |
+          if git status --porcelain openapi-schema.json | grep -q .; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add openapi-schema.json
+            git commit -m "chore: update OpenAPI schema"
+            git push
+          else
+            echo "No schema changes to commit"


### PR DESCRIPTION
## Summary
- allow the OpenAPI schema workflow to push changes by granting write permissions and committing updates
- ensure the checkout step fetches full history before pushing schema changes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d46806f31c8333835cc0399577ebd6