### PR TITLE
fix: gate openai tests on workflow env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tests
-    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    if: ${{ env.OPENAI_API_KEY != '' }}
     env:
       UV_PYTHON_VERSION: '3.12'
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
- fix the GitHub Actions condition for the live OpenAI tests to use the workflow env context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d46949dbc083339c352469f80760ab