### PR TITLE
feat: drive ingestion normalization with llm

### DIFF
--- a/app/activities/ingestion.py
+++ b/app/activities/ingestion.py
@@ -17,6 +17,7 @@ class NormalizeDocumentsResult(BaseModel):
     normalized_documents: Dict[str, str]
     audit_event: str
     metrics: Dict[str, float] = Field(default_factory=dict)
+    metadata: Dict[str, object] = Field(default_factory=dict)
 
 
 class IndexDocumentsInput(BaseModel):
@@ -37,15 +38,30 @@ async def normalize_documents(payload: NormalizeDocumentsInput) -> NormalizeDocu
     documents = {key: value for key, value in payload.raw_documents.items() if value}
     if not documents:
         raise ToolInvocationError("raw_documents missing from ingestion payload")
-    normalized = {key: " ".join(value.strip().split()) for key, value in documents.items() if value.strip()}
+    registry = get_registry()
+    try:
+        llm_result = registry.llm.ingest_documents(documents)
+    except ToolInvocationError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive guard around arbitrary tools
+        raise ToolInvocationError("Failed to ingest documents with LLM") from exc
+
+    llm_documents = llm_result.get("normalized_documents", {}) if isinstance(llm_result, dict) else {}
+    metadata = llm_result.get("metadata", {}) if isinstance(llm_result, dict) else {}
+    normalized = {
+        key: " ".join(value.strip().split())
+        for key, value in llm_documents.items()
+        if isinstance(value, str) and value.strip()
+    }
     if not normalized:
         raise ToolInvocationError("No documents contained usable content after normalization")
-    audit_label = f"ingestion.normalized:{','.join(sorted(normalized))}"
+    audit_label = f"ingestion.analyzed:{','.join(sorted(normalized))}"
     metrics = {"documents": float(len(normalized))}
     return NormalizeDocumentsResult(
         normalized_documents=normalized,
         audit_event=audit_label,
         metrics=metrics,
+        metadata=metadata if isinstance(metadata, dict) else {},
     )
 
 

--- a/app/workflows/resume.py
+++ b/app/workflows/resume.py
@@ -97,6 +97,8 @@ class ResumeWorkflow:
         self._apply_audit(normalize_result.audit_event)
         self._merge_metrics(normalize_result.metrics)
         self.state.artifacts["normalized_documents"] = normalize_result.normalized_documents
+        if normalize_result.metadata:
+            self.state.artifacts["ingestion_metadata"] = normalize_result.metadata
 
         index_result = await workflow.execute_activity(
             ingestion.index_documents,

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -63,3 +63,11 @@ class StubResumeLLM:
         if violations:
             return {"status": "rejected", "violations": violations}
         return {"status": "approved", "violations": []}
+
+    def ingest_documents(self, documents: Dict[str, str]) -> Dict[str, Any]:
+        cleaned = {key: value.strip() for key, value in documents.items() if value and value.strip()}
+        metadata = {
+            key: {"token_count": len(cleaned_value.split())}
+            for key, cleaned_value in cleaned.items()
+        }
+        return {"normalized_documents": cleaned, "metadata": metadata}

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -52,6 +52,7 @@ async def test_ingestion_flow(configure_stub_registry):
     )
     assert normalize_result.normalized_documents["resume"] == "First value"
     assert normalize_result.metrics == {"documents": 2.0}
+    assert normalize_result.metadata["resume"]["token_count"] == 2
 
     index_result = await index_documents(
         IndexDocumentsInput(


### PR DESCRIPTION
## Summary
- add an ingestion-specific prompt and schema to the OpenAIResumeLLM along with a new ingest_documents API on the registry protocol
- route normalize_documents through the llm analysis result, persisting metadata on the workflow state for downstream use
- extend the stub llm and activity tests to cover the new structured metadata returned during ingestion

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app


------
https://chatgpt.com/codex/tasks/task_e_68d4c56945f48333a5290b31bde9f6a8