### PR TITLE
feat: finalize chat workspace design refresh

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="api-base-url" content="" />
+    <title>Resume Assistant · Workspace</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="background" aria-hidden="true"></div>
+    <main class="shell" aria-label="Resume assistant workspace">
+      <header class="shell__header">
+        <div class="shell__header-top">
+          <div class="brand-block">
+            <span class="brand-block__icon" aria-hidden="true"></span>
+            <div>
+              <p class="brand-block__title">Resume Assistant</p>
+              <p class="brand-block__subtitle">Temporal workflow console</p>
+            </div>
+          </div>
+          <div class="shell__header-actions">
+            <span class="status-chip" role="status">API ready</span>
+            <button type="button" class="ghost-button" id="reset-workspace">Start over</button>
+          </div>
+        </div>
+        <div class="shell__headline">
+          <p class="eyebrow">Workflow overview</p>
+          <h1>Run a resume workflow from a single chat console.</h1>
+          <p class="lede">
+            Share context, pick a Temporal task, and watch the workflow respond. The interface
+            only surfaces data returned by the public API.
+          </p>
+        </div>
+      </header>
+
+      <section class="capsule shell__summary" aria-label="Workflow status and metrics">
+        <div class="snapshot">
+          <dl class="status-grid">
+            <div>
+              <dt>Workflow</dt>
+              <dd id="workflow-id">Not started</dd>
+            </div>
+            <div>
+              <dt>Task</dt>
+              <dd id="workflow-task">—</dd>
+            </div>
+            <div>
+              <dt>Stage</dt>
+              <dd id="workflow-stage">Waiting</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd id="workflow-status">Idle</dd>
+            </div>
+          </dl>
+          <ul class="metrics" aria-label="Session metrics">
+            <li>
+              <span class="metrics__icon" aria-hidden="true"></span>
+              <span class="metrics__value" id="metric-workflows">0</span>
+              <span class="metrics__label">Workflows started</span>
+            </li>
+            <li>
+              <span class="metrics__icon" aria-hidden="true"></span>
+              <span class="metrics__value" id="metric-messages">0</span>
+              <span class="metrics__label">Messages exchanged</span>
+            </li>
+            <li>
+              <span class="metrics__icon" aria-hidden="true"></span>
+              <span class="metrics__value" id="metric-artifacts">0</span>
+              <span class="metrics__label">Artifacts delivered</span>
+            </li>
+            <li>
+              <span class="metrics__icon metrics__icon--accent" aria-hidden="true"></span>
+              <span class="metrics__value metrics__value--accent" id="metric-approvals">Not requested</span>
+              <span class="metrics__label">Human approval</span>
+            </li>
+          </ul>
+        </div>
+        <div class="progress" aria-live="polite">
+          <p class="progress__label">Workflow progress</p>
+          <ol class="progress__list" id="stage-progress" aria-label="Workflow stages">
+            <li data-stage="route">
+              <span class="progress__step">Route</span>
+              <span class="progress__hint">Workflow queued</span>
+            </li>
+            <li data-stage="ingestion">
+              <span class="progress__step">Ingestion</span>
+              <span class="progress__hint">Processing context</span>
+            </li>
+            <li data-stage="drafting">
+              <span class="progress__step">Drafting</span>
+              <span class="progress__hint">Producing a draft</span>
+            </li>
+            <li data-stage="critique">
+              <span class="progress__step">Critique</span>
+              <span class="progress__hint">Reviewing quality</span>
+            </li>
+            <li data-stage="revision">
+              <span class="progress__step">Revision</span>
+              <span class="progress__hint">Applying updates</span>
+            </li>
+            <li data-stage="compliance">
+              <span class="progress__step">Compliance</span>
+              <span class="progress__hint">Running checks</span>
+            </li>
+            <li data-stage="publishing">
+              <span class="progress__step">Publishing</span>
+              <span class="progress__hint">Preparing outputs</span>
+            </li>
+            <li data-stage="done">
+              <span class="progress__step">Complete</span>
+              <span class="progress__hint">Workflow finished</span>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="conversation" id="chat-transcript" aria-live="polite" aria-label="Conversation history" data-empty-label="Share context to start a workflow."></section>
+
+      <form id="chat-form" class="composer" autocomplete="off" novalidate>
+        <label class="field" for="task-select">
+          <span class="field__label">Workflow task</span>
+          <select id="task-select" name="task">
+            <option value="ingest">Ingest career materials</option>
+            <option value="draft">Draft resume</option>
+            <option value="revise">Revise existing draft</option>
+            <option value="resume_pipeline">Full resume pipeline</option>
+            <option value="compliance_only">Compliance review only</option>
+            <option value="publish">Publish artifacts</option>
+          </select>
+        </label>
+
+        <label class="field" for="text-input">
+          <span class="field__label">Message to the workflow</span>
+          <textarea
+            id="text-input"
+            class="field__input"
+            name="message"
+            rows="3"
+            placeholder="Describe what the workflow should do with your resume data..."
+          ></textarea>
+          <p class="field__hint">The text is forwarded as part of the workflow request payload.</p>
+        </label>
+
+        <div class="composer__actions">
+          <button type="submit" class="primary-button">
+            <span>Start workflow</span>
+            <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+              <path d="M3 8h7.586l-2.293-2.293 1.414-1.414L14.414 9l-4.707 4.707-1.414-1.414L10.586 9H3z" />
+            </svg>
+          </button>
+        </div>
+      </form>
+
+      <p id="status-message" class="status-banner" role="status" aria-live="polite"></p>
+    </main>
+
+    <script src="workspace.js" type="module"></script>
+  </body>
+</html>

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -1,0 +1,673 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  --bg: hsl(228 52% 6%);
+  --bg-secondary: hsl(215 68% 10%);
+  --surface: hsla(230 55% 12% / 0.78);
+  --surface-light: hsla(0 0% 100% / 0.12);
+  --surface-border: hsla(0 0% 100% / 0.1);
+  --text: hsl(210 40% 96%);
+  --text-muted: hsla(210 40% 96% / 0.62);
+  --accent: hsl(210 100% 66%);
+  --accent-strong: hsl(214 100% 58%);
+  --accent-soft: hsla(210 100% 70% / 0.18);
+  --danger: hsl(352 84% 62%);
+  --success: hsl(146 72% 45%);
+  --chip: hsla(210 90% 70% / 0.18);
+  --shadow: 0 28px 70px -36px rgba(5, 14, 34, 0.75);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(20px, 4vw, 36px);
+  background: radial-gradient(circle at 12% 18%, hsla(199 100% 65% / 0.35), transparent 55%),
+    radial-gradient(circle at 88% 8%, hsla(285 100% 72% / 0.3), transparent 55%),
+    radial-gradient(circle at 70% 88%, hsla(160 95% 60% / 0.28), transparent 55%),
+    linear-gradient(120deg, var(--bg), var(--bg-secondary));
+  color: var(--text);
+  position: relative;
+  overflow: hidden;
+}
+
+.background {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 10% 20%, hsla(200 100% 60% / 0.4), transparent 55%),
+    radial-gradient(circle at 80% 10%, hsla(280 100% 70% / 0.35), transparent 50%),
+    radial-gradient(circle at 70% 80%, hsla(160 95% 55% / 0.35), transparent 55%),
+    linear-gradient(120deg, hsl(226 70% 12%), hsl(215 68% 10%));
+  filter: blur(26px);
+  transform: scale(1.15);
+  z-index: 0;
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  width: min(960px, 100%);
+  display: grid;
+  grid-template-rows: auto auto 1fr auto auto;
+  gap: clamp(18px, 3vw, 28px);
+  padding: clamp(24px, 4vw, 36px);
+  border-radius: 28px;
+  background: var(--surface);
+  backdrop-filter: blur(28px) saturate(170%);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, hsla(210 90% 65% / 0.2), transparent 45%, hsla(285 90% 65% / 0.2));
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.shell__header {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.shell__header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.brand-block {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.brand-block__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  position: relative;
+  box-shadow: 0 18px 30px -18px hsla(210 100% 66% / 0.85);
+}
+
+.brand-block__icon::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 12px;
+  background: hsla(0 0% 100% / 0.18);
+  backdrop-filter: blur(4px);
+}
+
+.brand-block__title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.brand-block__subtitle {
+  margin: 2px 0 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--text-muted);
+}
+
+.shell__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--chip);
+  border: 1px solid hsla(210 100% 80% / 0.3);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.shell__headline {
+  display: grid;
+  gap: 8px;
+}
+
+.eyebrow {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 2.2vw + 1.1rem, 2.6rem);
+  line-height: 1.08;
+}
+
+.lede {
+  margin: 0;
+  max-width: 560px;
+  color: var(--text-muted);
+}
+
+.capsule {
+  position: relative;
+  z-index: 1;
+  padding: clamp(18px, 3vw, 24px);
+  border-radius: 20px;
+  background: var(--surface-light);
+  border: 1px solid var(--surface-border);
+  display: grid;
+  gap: 24px;
+}
+
+.shell__summary {
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 260px);
+}
+
+.snapshot {
+  display: grid;
+  gap: 22px;
+}
+
+.status-grid {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+}
+
+.status-grid dt {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.status-grid dd {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+
+.metrics {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 18px;
+}
+
+.metrics li {
+  display: grid;
+  gap: 6px;
+  position: relative;
+  padding-left: 36px;
+}
+
+.metrics__icon {
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 10px;
+  background: linear-gradient(140deg, hsla(210 100% 70% / 0.45), hsla(214 100% 60% / 0.6));
+  border: 1px solid hsla(210 100% 80% / 0.35);
+  box-shadow: 0 12px 24px -18px hsla(210 100% 70% / 0.7);
+}
+
+.metrics__icon::after {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border-radius: 7px;
+  background: hsla(0 0% 100% / 0.16);
+}
+
+.metrics__icon--accent {
+  background: linear-gradient(140deg, hsla(210 100% 70% / 0.32), hsla(160 95% 55% / 0.42));
+  box-shadow: 0 12px 24px -18px hsla(160 95% 60% / 0.55);
+}
+
+.metrics__value {
+  font-weight: 600;
+  font-size: 1.2rem;
+}
+
+
+.metrics__value--accent {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+}
+
+.metrics__label {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.progress {
+  align-self: stretch;
+  padding: clamp(16px, 2.4vw, 22px);
+  border-radius: 18px;
+  background: hsla(222 55% 10% / 0.7);
+  border: 1px solid hsla(0 0% 100% / 0.08);
+  display: grid;
+  gap: 14px;
+  box-shadow: inset 0 0 0 1px hsla(0 0% 100% / 0.02);
+}
+
+.progress__label {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--text-muted);
+}
+
+.progress__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 14px;
+}
+
+.progress__list li {
+  position: relative;
+  padding-left: 32px;
+  display: grid;
+  gap: 2px;
+  min-height: 28px;
+}
+
+.progress__list li::before {
+  content: "";
+  position: absolute;
+  left: 6px;
+  top: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  border: 1px solid hsla(210 60% 70% / 0.45);
+  background: hsla(220 55% 18% / 0.6);
+  box-shadow: inset 0 0 0 1px hsla(0 0% 100% / 0.12);
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.progress__list li::after {
+  content: "";
+  position: absolute;
+  top: 22px;
+  left: 11px;
+  width: 2px;
+  height: calc(100% - 24px);
+  background: hsla(210 60% 70% / 0.18);
+}
+
+.progress__list li:last-child::after {
+  display: none;
+}
+
+.progress__step {
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.progress__hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.progress__list li.is-complete::before {
+  background: linear-gradient(135deg, hsla(210 100% 66% / 0.9), hsla(214 100% 58% / 0.9));
+  border-color: transparent;
+  transform: scale(1.05);
+}
+
+.progress__list li.is-active::before {
+  background: linear-gradient(135deg, hsla(210 100% 66% / 1), hsla(214 100% 56% / 1));
+  border-color: transparent;
+  transform: scale(1.2);
+  box-shadow: 0 0 0 4px hsla(210 100% 66% / 0.18);
+}
+
+.conversation {
+  position: relative;
+  padding: clamp(22px, 3vw, 26px);
+  border-radius: 22px;
+  background: hsla(225 55% 12% / 0.88);
+  border: 1px solid hsla(220 60% 40% / 0.12);
+  min-height: clamp(260px, 42vh, 460px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: inset 0 0 0 1px hsla(0 0% 100% / 0.04);
+  backdrop-filter: blur(14px) saturate(140%);
+}
+
+.conversation::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, transparent, hsla(229 45% 10% / 0.78));
+  opacity: 0.38;
+}
+
+.conversation.is-empty::before {
+  content: attr(data-empty-label);
+  color: var(--text-muted);
+  text-align: center;
+  margin: auto;
+  font-size: 0.95rem;
+}
+
+.conversation::-webkit-scrollbar {
+  width: 6px;
+}
+
+.conversation::-webkit-scrollbar-thumb {
+  background: hsla(210 30% 60% / 0.35);
+  border-radius: 999px;
+}
+
+.message {
+  position: relative;
+  padding: clamp(16px, 3vw, 20px);
+  border-radius: 18px;
+  background: linear-gradient(145deg, hsla(228 60% 18% / 0.82), hsla(230 55% 12% / 0.78));
+  border: 1px solid hsla(0 0% 100% / 0.06);
+  display: grid;
+  gap: 12px;
+  max-width: min(620px, 100%);
+  box-shadow: 0 18px 48px -30px rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(6px);
+}
+
+.message::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 16px;
+  border: 1px solid hsla(0 0% 100% / 0.05);
+  pointer-events: none;
+}
+
+.message.user {
+  margin-left: auto;
+  background: linear-gradient(145deg, hsla(210 100% 66% / 0.75), hsla(214 100% 58% / 0.82));
+  color: hsl(220 100% 97%);
+}
+
+.message.assistant {
+  background: linear-gradient(145deg, hsla(228 60% 18% / 0.92), hsla(230 55% 14% / 0.88));
+}
+
+.message.system {
+  background: linear-gradient(145deg, hsla(50 100% 58% / 0.2), hsla(48 100% 50% / 0.12));
+  color: var(--text);
+}
+
+.message__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.message__body {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.message__detail {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.composer {
+  position: relative;
+  display: grid;
+  gap: 18px;
+  padding: clamp(18px, 3vw, 22px);
+  border-radius: 20px;
+  background: hsla(222 55% 10% / 0.82);
+  border: 1px solid var(--surface-border);
+  box-shadow: inset 0 0 0 1px hsla(0 0% 100% / 0.04);
+}
+
+.composer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  background: linear-gradient(120deg, transparent 40%, hsla(210 100% 66% / 0.12));
+  pointer-events: none;
+}
+
+.composer.is-busy {
+  opacity: 0.72;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.field__input,
+select {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: hsla(223 65% 12% / 0.9);
+  color: var(--text);
+  border: 1px solid var(--surface-border);
+  font: inherit;
+  resize: vertical;
+  min-height: 120px;
+}
+
+select {
+  min-height: auto;
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--text) 50%),
+    linear-gradient(135deg, var(--text) 50%, transparent 50%);
+  background-position: calc(100% - 18px) 50%, calc(100% - 12px) 50%;
+  background-size: 6px 6px;
+  background-repeat: no-repeat;
+  padding-right: 44px;
+}
+
+.field__input:focus,
+select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.field__hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.composer__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.primary-button,
+.ghost-button,
+.status-banner__button {
+  border-radius: 999px;
+  border: none;
+  padding: 12px 22px;
+  font-weight: 600;
+  cursor: pointer;
+  font: inherit;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: white;
+  box-shadow: 0 14px 30px -18px var(--accent-strong);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.primary-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary-button svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.primary-button:not(:disabled):active {
+  transform: translateY(1px);
+}
+
+.ghost-button {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--surface-border);
+}
+
+.ghost-button:hover,
+.status-banner__button:hover {
+  transform: translateY(-1px);
+}
+
+.ghost-button:focus-visible,
+.primary-button:focus-visible,
+.status-banner__button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.status-banner {
+  margin: 0;
+  padding: 12px 18px;
+  border-radius: 14px;
+  background: hsla(223 65% 12% / 0.8);
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 48px;
+}
+
+.status-banner.is-success {
+  border-color: hsla(146 72% 45% / 0.4);
+  color: var(--success);
+}
+
+.status-banner.is-error {
+  border-color: hsla(352 84% 62% / 0.4);
+  color: var(--danger);
+}
+
+.status-banner.is-pending {
+  border-color: hsla(208 92% 62% / 0.4);
+  color: var(--accent);
+}
+
+.status-banner__actions {
+  display: flex;
+  gap: 10px;
+}
+
+.status-banner__button {
+  background: hsla(223 65% 18% / 0.9);
+  border: 1px solid var(--surface-border);
+  color: var(--text);
+}
+
+.status-banner__button.is-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border: none;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 16px;
+  }
+
+  .shell {
+    padding: 22px;
+    gap: 16px;
+  }
+
+  .shell__summary {
+    grid-template-columns: 1fr;
+  }
+
+  .progress {
+    order: -1;
+  }
+
+  .conversation {
+    padding: 18px;
+  }
+
+  .composer {
+    padding: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}

--- a/app/frontend/workspace.js
+++ b/app/frontend/workspace.js
@@ -1,0 +1,673 @@
+const transcript = document.getElementById("chat-transcript");
+const workspaceForm = document.getElementById("chat-form");
+const textInput = document.getElementById("text-input");
+const taskSelect = document.getElementById("task-select");
+const statusBanner = document.getElementById("status-message");
+const workflowIdLabel = document.getElementById("workflow-id");
+const workflowTaskLabel = document.getElementById("workflow-task");
+const workflowStageLabel = document.getElementById("workflow-stage");
+const workflowStatusLabel = document.getElementById("workflow-status");
+const resetButton = document.getElementById("reset-workspace");
+const metricWorkflows = document.getElementById("metric-workflows");
+const metricMessages = document.getElementById("metric-messages");
+const metricArtifacts = document.getElementById("metric-artifacts");
+const metricApproval = document.getElementById("metric-approvals");
+const stageProgressList = document.getElementById("stage-progress");
+
+const apiMeta = document.querySelector('meta[name="api-base-url"]');
+const API_ROOT = (apiMeta?.content ?? "").replace(/\/$/, "");
+const POLL_BASE_INTERVAL = 1500;
+const POLL_MAX_INTERVAL = 5500;
+
+const STAGE_LABELS = {
+  route: "Routing",
+  ingestion: "Ingestion",
+  drafting: "Drafting",
+  critique: "Critique",
+  revision: "Revision",
+  compliance: "Compliance",
+  publishing: "Publishing",
+  done: "Complete",
+};
+
+const STAGE_HINT = {
+  route: "Workflow queued",
+  ingestion: "Processing uploaded context",
+  drafting: "Drafting the next resume output",
+  critique: "Reviewing draft quality",
+  revision: "Applying requested revisions",
+  compliance: "Running compliance checks",
+  publishing: "Preparing final artifacts",
+  done: "Finalizing response",
+};
+
+const STAGE_SEQUENCE = [
+  "route",
+  "ingestion",
+  "drafting",
+  "critique",
+  "revision",
+  "compliance",
+  "publishing",
+  "done",
+];
+
+const conversation = [];
+const messageCache = new Set();
+const approvalState = { workflowId: null, pendingDecision: false };
+const metrics = { workflowsStarted: 0, artifactsDelivered: 0 };
+let approvalMetricStatus = "Not requested";
+let activeWorkflow = {
+  id: null,
+  task: null,
+  requestId: null,
+  stage: null,
+  pollController: null,
+};
+
+const initialGreeting = {
+  role: "assistant",
+  content:
+    "Share resume context or requests and choose a workflow task. I'll relay it to the Temporal workflow and surface each update the API returns.",
+  timestamp: new Date(),
+};
+conversation.push(initialGreeting);
+messageCache.add(createMessageKey(initialGreeting));
+renderTranscript();
+setStatus("You're ready to start a workflow.", "success");
+updateSummary();
+setApprovalMetric("Not requested");
+refreshMetrics();
+renderStageProgress();
+
+workspaceForm?.addEventListener("submit", handleSubmit);
+textInput?.addEventListener("input", autoResize);
+textInput?.addEventListener("focus", autoResize);
+textInput?.addEventListener("keydown", (event) => {
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault();
+    workspaceForm?.requestSubmit();
+  }
+});
+resetButton?.addEventListener("click", resetWorkspace);
+
+function autoResize() {
+  if (!textInput) {
+    return;
+  }
+  textInput.style.height = "auto";
+  textInput.style.height = `${Math.min(textInput.scrollHeight, 240)}px`;
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  if (!workspaceForm) {
+    return;
+  }
+  const message = textInput?.value?.trim() ?? "";
+  if (!message) {
+    setStatus("Add instructions for the workflow first.", "error");
+    return;
+  }
+  const task = taskSelect?.value ?? "resume_pipeline";
+
+  const userMessage = {
+    role: "human",
+    content: message,
+    timestamp: new Date(),
+  };
+  addMessage(userMessage);
+
+  const requestId = crypto.randomUUID?.() ?? `workspace-${Date.now()}`;
+  const payload = createWorkflowPayload({ message, task, requestId });
+
+  try {
+    setComposerBusy(true);
+    setStatus("Starting workflow...", "pending");
+    const response = await startWorkflow(payload);
+    activeWorkflow.id = response.workflow_id;
+    activeWorkflow.task = task;
+    activeWorkflow.requestId = requestId;
+    metrics.workflowsStarted += 1;
+    refreshMetrics();
+    updateSummary({
+      workflowId: response.workflow_id,
+      task,
+      stage: "route",
+      status: "in_progress",
+    });
+    beginPolling(response.workflow_id);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    setStatus(detail || "Failed to start workflow", "error");
+    addMessage({
+      role: "system",
+      content: "The request did not reach the workflow service. Double-check the API and try again.",
+      timestamp: new Date(),
+    });
+  } finally {
+    if (textInput) {
+      textInput.value = "";
+      autoResize();
+    }
+    setComposerBusy(false);
+  }
+}
+
+function addMessage(entry) {
+  const key = createMessageKey(entry);
+  if (!messageCache.has(key)) {
+    messageCache.add(key);
+    conversation.push({ ...entry });
+    if (entry.type === "artifact") {
+      registerArtifact();
+    }
+    refreshMetrics();
+    renderTranscript();
+  }
+}
+
+function createMessageKey(entry) {
+  return `${entry.role}|${entry.content}`;
+}
+
+function renderTranscript() {
+  if (!transcript) {
+    return;
+  }
+  transcript.innerHTML = "";
+  if (!conversation.length) {
+    transcript.classList.add("is-empty");
+    return;
+  }
+  transcript.classList.remove("is-empty");
+  for (const entry of conversation) {
+    transcript.appendChild(createMessageNode(entry));
+  }
+  transcript.scrollTop = transcript.scrollHeight;
+}
+
+function createMessageNode(entry) {
+  const article = document.createElement("article");
+  const roleClass = entry.role === "assistant" ? "assistant" : entry.role === "system" ? "system" : "user";
+  article.className = `message ${roleClass}`;
+
+  const meta = document.createElement("div");
+  meta.className = "message__meta";
+  const roleLabel = entry.role === "assistant" ? "Assistant" : entry.role === "system" ? "System" : "You";
+  meta.appendChild(document.createTextNode(roleLabel));
+  const timeStamp = document.createElement("span");
+  timeStamp.textContent = formatTimestamp(entry.timestamp);
+  meta.appendChild(timeStamp);
+
+  const body = document.createElement("p");
+  body.className = "message__body";
+  body.textContent = entry.content;
+  article.append(meta, body);
+
+  if (entry.detail) {
+    const detail = document.createElement("p");
+    detail.className = "message__detail";
+    detail.textContent = entry.detail;
+    article.appendChild(detail);
+  }
+
+  return article;
+}
+
+function formatTimestamp(value) {
+  const date = value ? new Date(value) : new Date();
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function setComposerBusy(isBusy) {
+  if (!workspaceForm) {
+    return;
+  }
+  workspaceForm.classList.toggle("is-busy", isBusy);
+  const submit = workspaceForm.querySelector("button[type='submit']");
+  if (submit) {
+    submit.disabled = isBusy;
+  }
+  if (textInput) {
+    textInput.disabled = isBusy;
+  }
+  if (taskSelect) {
+    taskSelect.disabled = isBusy;
+  }
+}
+
+function createWorkflowPayload({ message, task, requestId }) {
+  const artifacts = message ? { notes: message } : {};
+  return {
+    task,
+    request_id: requestId,
+    artifacts,
+    flags: {
+      source: "workspace",
+    },
+  };
+}
+
+async function startWorkflow(payload) {
+  const response = await fetchJson(apiUrl("/workflows/resume"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response?.workflow_id) {
+    throw new Error("Workflow response did not include an identifier");
+  }
+  return response;
+}
+
+function beginPolling(workflowId) {
+  if (activeWorkflow.pollController) {
+    activeWorkflow.pollController.abort();
+  }
+  const controller = new AbortController();
+  activeWorkflow.pollController = controller;
+  void pollWorkflowState({ workflowId, signal: controller.signal });
+}
+
+async function pollWorkflowState({ workflowId, signal }) {
+  let attempt = 0;
+  let finalState = null;
+  while (!signal.aborted) {
+    let state = null;
+    try {
+      state = await fetchWorkflowState(workflowId);
+    } catch (error) {
+      if (signal.aborted) {
+        return;
+      }
+      setStatus(
+        error instanceof Error ? error.message : "Unable to reach the workflow state endpoint.",
+        "error",
+      );
+      addMessage({
+        role: "system",
+        content: "Polling stopped due to a network error.",
+        timestamp: new Date(),
+      });
+      return;
+    }
+    if (!state) {
+      setStatus("Workflow state unavailable.", "error");
+      return;
+    }
+
+    applyWorkflowState(state);
+
+    if (state.status === "complete" || state.status === "error") {
+      finalState = state;
+      break;
+    }
+
+    const delay = Math.min(POLL_BASE_INTERVAL + attempt * 400, POLL_MAX_INTERVAL);
+    attempt += 1;
+    try {
+      await wait(delay, signal);
+    } catch (error) {
+      return;
+    }
+  }
+
+  if (!finalState || signal.aborted) {
+    return;
+  }
+
+  if (finalState.status === "complete") {
+    try {
+      const resultState = await fetchWorkflowResult(workflowId);
+      if (resultState) {
+        finalState = resultState;
+        applyWorkflowState(resultState);
+      }
+    } catch (error) {
+      // continue with latest state
+    }
+  }
+
+  finalizeWorkflow(finalState);
+}
+
+function applyWorkflowState(state) {
+  updateSummary({
+    workflowId: state.request_id ?? activeWorkflow.id,
+    task: state.task,
+    stage: state.stage,
+    status: state.status,
+  });
+  syncMessagesFromState(state);
+  handleStageTransition(state.stage);
+
+  if (state.flags?.awaiting_human) {
+    showApprovalControls(activeWorkflow.id ?? state.request_id);
+  } else {
+    hideApprovalControls();
+  }
+
+  const hint = STAGE_HINT[state.stage];
+  if (state.status === "in_progress" && hint) {
+    setStatus(hint, "pending");
+  }
+}
+
+function syncMessagesFromState(state) {
+  const messages = Array.isArray(state.messages) ? state.messages : [];
+  for (const entry of messages) {
+    if (!entry || typeof entry.content !== "string") {
+      continue;
+    }
+    const normalizedRole = entry.role === "human" ? "human" : entry.role === "system" ? "system" : "assistant";
+    addMessage({
+      role: normalizedRole,
+      content: entry.content,
+      timestamp: new Date(),
+    });
+  }
+
+  if (state.status === "error" && state.flags?.human_notes) {
+    addMessage({
+      role: "system",
+      content: "Workflow reported an error.",
+      detail: state.flags.human_notes,
+      timestamp: new Date(),
+    });
+  }
+
+  if (state.status === "complete") {
+    const artifacts = state.artifacts ?? {};
+    if (typeof artifacts.draft_resume === "string" && artifacts.draft_resume.trim()) {
+      addMessage({
+        role: "assistant",
+        content: artifacts.draft_resume.trim(),
+        timestamp: new Date(),
+        type: "artifact",
+      });
+    } else if (typeof artifacts.published_resume === "string") {
+      addMessage({
+        role: "assistant",
+        content: artifacts.published_resume.trim(),
+        timestamp: new Date(),
+        type: "artifact",
+      });
+    }
+  }
+}
+
+function handleStageTransition(stage) {
+  if (!stage || activeWorkflow.stage === stage) {
+    return;
+  }
+  activeWorkflow.stage = stage;
+  renderStageProgress(stage);
+  const label = STAGE_LABELS[stage] ?? stage;
+  addMessage({
+    role: "system",
+    content: `Stage updated: ${label}`,
+    timestamp: new Date(),
+  });
+}
+
+function finalizeWorkflow(state) {
+  if (state.status === "error") {
+    setStatus("Workflow ended with an error.", "error");
+  } else {
+    setStatus("Workflow completed.", "success");
+  }
+  setComposerBusy(false);
+  activeWorkflow.pollController = null;
+}
+
+function showApprovalControls(workflowId) {
+  if (!workflowId || approvalState.pendingDecision) {
+    return;
+  }
+  if (approvalState.workflowId === workflowId) {
+    return;
+  }
+  approvalState.workflowId = workflowId;
+  setApprovalMetric("Action required");
+  setStatus("Workflow is waiting for your approval.", "pending", {
+    buttons: [
+      {
+        label: "Approve",
+        variant: "primary",
+        onClick: () => void handleApprovalDecision(workflowId, true),
+      },
+      {
+        label: "Request changes",
+        onClick: () => void handleApprovalDecision(workflowId, false),
+      },
+    ],
+  });
+}
+
+function hideApprovalControls() {
+  approvalState.workflowId = null;
+  approvalState.pendingDecision = false;
+  if (approvalMetricStatus === "Action required") {
+    setApprovalMetric("Not requested");
+  }
+}
+
+async function handleApprovalDecision(workflowId, approved) {
+  approvalState.pendingDecision = true;
+  setStatus(approved ? "Submitting approval..." : "Requesting changes...", "pending");
+  try {
+    await submitWorkflowApproval(workflowId, approved);
+    approvalState.pendingDecision = false;
+    setStatus("Decision submitted.", "success");
+    setApprovalMetric(approved ? "Approved" : "Changes requested");
+  } catch (error) {
+    approvalState.pendingDecision = false;
+    approvalState.workflowId = workflowId;
+    setStatus(
+      error instanceof Error ? error.message : "Failed to submit decision.",
+      "error",
+      {
+        buttons: [
+          {
+            label: "Retry",
+            variant: "primary",
+            onClick: () => void handleApprovalDecision(workflowId, approved),
+          },
+        ],
+      },
+    );
+  }
+}
+
+function updateSummary({ workflowId, task, stage, status } = {}) {
+  if (workflowIdLabel) {
+    workflowIdLabel.textContent = workflowId ?? "Not started";
+  }
+  if (workflowTaskLabel) {
+    workflowTaskLabel.textContent = task ?? "—";
+  }
+  if (workflowStageLabel) {
+    workflowStageLabel.textContent = stage ? STAGE_LABELS[stage] ?? stage : "Waiting";
+  }
+  if (workflowStatusLabel) {
+    workflowStatusLabel.textContent = status ? status.replaceAll("_", " ") : "Idle";
+  }
+  renderStageProgress(stage);
+}
+
+function setStatus(message, variant, actionConfig) {
+  if (!statusBanner) {
+    return;
+  }
+  statusBanner.classList.remove("is-success", "is-error", "is-pending");
+  statusBanner.replaceChildren();
+  if (variant) {
+    statusBanner.classList.add(`is-${variant}`);
+  }
+  statusBanner.append(document.createTextNode(message ?? ""));
+  if (actionConfig?.buttons?.length) {
+    const actions = document.createElement("span");
+    actions.className = "status-banner__actions";
+    for (const config of actionConfig.buttons) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "status-banner__button";
+      if (config.variant === "primary") {
+        button.classList.add("is-primary");
+      }
+      button.textContent = config.label;
+      if (typeof config.onClick === "function") {
+        button.addEventListener("click", config.onClick);
+      }
+      actions.appendChild(button);
+    }
+    statusBanner.append(actions);
+  }
+}
+
+async function fetchWorkflowState(workflowId) {
+  const response = await fetchJson(apiUrl(`/workflows/${workflowId}`));
+  return response?.state ?? null;
+}
+
+async function fetchWorkflowResult(workflowId) {
+  const response = await fetchJson(apiUrl(`/workflows/${workflowId}/result`));
+  return response?.state ?? null;
+}
+
+async function submitWorkflowApproval(workflowId, approved) {
+  await fetchJson(apiUrl(`/workflows/${workflowId}/approval`), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ approved }),
+  });
+}
+
+async function fetchJson(url, options) {
+  let response;
+  try {
+    response = await fetch(url, options);
+  } catch (error) {
+    throw new Error("Network request failed");
+  }
+  if (!response.ok) {
+    let detail;
+    try {
+      const payload = await response.json();
+      detail = payload?.detail ?? payload?.message;
+    } catch (error) {
+      detail = await response.text();
+    }
+    throw new Error(detail || `Request failed with status ${response.status}`);
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new Error("Invalid JSON response from server");
+  }
+}
+
+function apiUrl(path) {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${API_ROOT}${normalized}` || normalized;
+}
+
+function wait(duration, signal) {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, duration);
+    const onAbort = () => {
+      window.clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    if (signal) {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+function resetWorkspace() {
+  if (activeWorkflow.pollController) {
+    activeWorkflow.pollController.abort();
+  }
+  activeWorkflow = {
+    id: null,
+    task: null,
+    requestId: null,
+    stage: null,
+    pollController: null,
+  };
+  approvalState.workflowId = null;
+  approvalState.pendingDecision = false;
+  metrics.workflowsStarted = 0;
+  metrics.artifactsDelivered = 0;
+  conversation.splice(0, conversation.length, initialGreeting);
+  messageCache.clear();
+  messageCache.add(createMessageKey(initialGreeting));
+  renderTranscript();
+  updateSummary();
+  renderStageProgress();
+  setStatus("Workspace cleared.", "success");
+  setApprovalMetric("Not requested");
+  refreshMetrics();
+  if (textInput) {
+    textInput.disabled = false;
+    textInput.value = "";
+    autoResize();
+  }
+  if (taskSelect) {
+    taskSelect.disabled = false;
+    taskSelect.value = "ingest";
+  }
+}
+
+function refreshMetrics() {
+  if (metricWorkflows) {
+    metricWorkflows.textContent = String(metrics.workflowsStarted);
+  }
+  if (metricMessages) {
+    const total = Math.max(conversation.length - 1, 0);
+    metricMessages.textContent = String(total);
+  }
+  if (metricArtifacts) {
+    metricArtifacts.textContent = String(metrics.artifactsDelivered);
+  }
+}
+
+function registerArtifact() {
+  metrics.artifactsDelivered += 1;
+}
+
+function setApprovalMetric(value) {
+  approvalMetricStatus = value;
+  if (metricApproval) {
+    metricApproval.textContent = value;
+  }
+}
+
+function renderStageProgress(stage) {
+  if (!stageProgressList) {
+    return;
+  }
+  const stageIndex = stage ? STAGE_SEQUENCE.indexOf(stage) : -1;
+  const items = stageProgressList.querySelectorAll("li[data-stage]");
+  items.forEach((item) => {
+    const itemStage = item.dataset.stage;
+    const itemIndex = STAGE_SEQUENCE.indexOf(itemStage);
+    const isActive = stageIndex >= 0 && itemStage === stage;
+    const isComplete = stageIndex > 0 && itemIndex > -1 && itemIndex < stageIndex;
+    item.classList.toggle("is-active", isActive);
+    item.classList.toggle("is-complete", isComplete);
+    if (isActive) {
+      item.setAttribute("aria-current", "step");
+    } else {
+      item.removeAttribute("aria-current");
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- reorganize the workspace summary capsule with icon metrics and a live stage progress list that mirrors API state
- wire the client controller to drive the new progress tracker across stage transitions and workspace resets
- soften the conversation surfaces and message treatments to better align with the refreshed single-column layout

## Testing
- uv run pytest
- uv run --extra dev ruff check
- uv run --extra dev mypy app

------
https://chatgpt.com/codex/tasks/task_e_68d4cb46e63c83338d2d218e1012babd