### PR TITLE
fix: lazy load tool registry for workflows

### DIFF
--- a/apps/backend/app/activities/__init__.py
+++ b/apps/backend/app/activities/__init__.py
@@ -1,22 +1,28 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, TYPE_CHECKING
 
-from ..tools import ToolRegistry, build_default_registry
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from ..tools import ToolRegistry
 
-_REGISTRY: ToolRegistry | None = None
+_REGISTRY: "ToolRegistry | None" = None
 
 
-def configure_registry(registry: Optional[ToolRegistry] = None) -> ToolRegistry:
+def configure_registry(registry: Optional["ToolRegistry"] = None) -> "ToolRegistry":
     """Set the registry used by activities and return it for convenience."""
 
     global _REGISTRY
-    resolved = registry or build_default_registry()
+    if registry is None:
+        from ..tools import build_default_registry
+
+        resolved = build_default_registry()
+    else:
+        resolved = registry
     _REGISTRY = resolved
     return resolved
 
 
-def get_registry() -> ToolRegistry:
+def get_registry() -> "ToolRegistry":
     if _REGISTRY is None:  # pragma: no cover - defensive guard
         raise RuntimeError("Activity registry has not been configured")
     return _REGISTRY


### PR DESCRIPTION
## Summary
- avoid importing the OpenAI-backed tool registry when workflows are imported
- lazy load the default registry only when activities configure it

## Testing
- uv run ruff check apps/backend/app/activities/__init__.py *(fails: pyenv missing ruff runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a4d89900833391545904134e22d7