### PR TITLE
feat(frontend): refresh chat workspace design

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap");
 
 :root {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -9,92 +9,106 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  --heading-font: "Fraunces", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --bg-gradient: radial-gradient(circle at 10% -10%, rgba(255, 202, 138, 0.38), transparent 55%),
-    radial-gradient(circle at 90% 0%, rgba(173, 210, 201, 0.35), transparent 45%),
-    linear-gradient(145deg, #f6ede4 0%, #f0f4ef 45%, #f3e8f2 100%);
-  --text-primary: #2f2118;
-  --text-muted: #6f5a4f;
-  --text-subtle: #8d776b;
-  --text-inverse: #fff9f3;
-  --surface-primary: rgba(255, 255, 255, 0.78);
-  --surface-secondary: rgba(255, 255, 255, 0.66);
-  --surface-muted: rgba(255, 255, 255, 0.55);
-  --surface-elevated: rgba(255, 255, 255, 0.85);
-  --surface-code: rgba(255, 249, 242, 0.86);
-  --surface-pill: rgba(255, 255, 255, 0.72);
-  --border-strong: rgba(202, 178, 158, 0.6);
-  --border-soft: rgba(202, 178, 158, 0.35);
-  --border-subtle: rgba(202, 178, 158, 0.25);
-  --shadow-lg: 0 48px 96px rgba(122, 93, 67, 0.22);
-  --shadow-md: 0 30px 60px rgba(122, 93, 67, 0.18);
-  --shadow-sm: 0 16px 32px rgba(122, 93, 67, 0.12);
-  --accent: #b87b45;
-  --accent-strong: #9c5f30;
-  --accent-soft: rgba(184, 123, 69, 0.18);
-  --accent-pill-text: #74492a;
-  --focus-ring: rgba(184, 123, 69, 0.5);
-  --success: #3c7f65;
-  --success-soft: rgba(60, 127, 101, 0.16);
-  --warning: #d9913c;
-  --warning-soft: rgba(217, 145, 60, 0.18);
-  --danger: #c86657;
-  --danger-soft: rgba(200, 102, 87, 0.18);
-  --message-user-bg: rgba(233, 245, 240, 0.86);
-  --message-user-border: rgba(144, 188, 168, 0.45);
-  --message-assistant-bg: rgba(250, 239, 230, 0.88);
-  --message-assistant-border: rgba(214, 176, 138, 0.5);
-  --message-system-bg: rgba(243, 236, 231, 0.85);
-  --message-system-border: var(--border-soft);
-  --attachment-bg: rgba(255, 255, 255, 0.72);
+  --heading-font: "Instrument Sans", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg-gradient: radial-gradient(circle at 10% -20%, rgba(79, 70, 229, 0.16), transparent 55%),
+    radial-gradient(circle at 90% 0%, rgba(14, 165, 233, 0.22), transparent 50%),
+    linear-gradient(180deg, #f8fafc 0%, #eef2ff 60%, #f9fafb 100%);
+  --text-primary: #0f172a;
+  --text-muted: #1e293b;
+  --text-subtle: #475569;
+  --text-inverse: #f8fafc;
+  --surface-primary: rgba(255, 255, 255, 0.95);
+  --surface-secondary: rgba(248, 250, 252, 0.88);
+  --surface-muted: rgba(226, 232, 240, 0.6);
+  --surface-elevated: rgba(255, 255, 255, 0.9);
+  --surface-code: rgba(226, 232, 240, 0.72);
+  --surface-shell: rgba(255, 255, 255, 0.82);
+  --panel-gradient: linear-gradient(150deg, #111827 0%, #1e293b 55%, #0f172a 100%);
+  --panel-border: rgba(148, 163, 184, 0.28);
+  --panel-shadow: 0 40px 70px rgba(15, 23, 42, 0.3);
+  --panel-text: #f8fafc;
+  --panel-text-muted: rgba(226, 232, 240, 0.85);
+  --panel-text-subtle: rgba(203, 213, 225, 0.75);
+  --panel-indicator: rgba(255, 255, 255, 0.9);
+  --border-strong: rgba(148, 163, 184, 0.35);
+  --border-soft: rgba(148, 163, 184, 0.28);
+  --border-subtle: rgba(148, 163, 184, 0.2);
+  --shadow-lg: 0 35px 90px rgba(15, 23, 42, 0.18);
+  --shadow-md: 0 22px 48px rgba(15, 23, 42, 0.12);
+  --shadow-sm: 0 15px 30px rgba(15, 23, 42, 0.1);
+  --accent: #6366f1;
+  --accent-strong: #4f46e5;
+  --accent-soft: rgba(99, 102, 241, 0.14);
+  --focus-ring: rgba(99, 102, 241, 0.4);
+  --success: #0ec57e;
+  --success-soft: rgba(14, 197, 126, 0.15);
+  --warning: #facc15;
+  --warning-soft: rgba(250, 204, 21, 0.16);
+  --danger: #ef4444;
+  --danger-soft: rgba(239, 68, 68, 0.16);
+  --danger-strong: #b91c1c;
+  --message-user-bg: rgba(222, 247, 250, 0.95);
+  --message-user-border: rgba(14, 165, 233, 0.35);
+  --message-assistant-bg: rgba(240, 236, 255, 0.92);
+  --message-assistant-border: rgba(99, 102, 241, 0.32);
+  --message-system-bg: rgba(241, 245, 249, 0.88);
+  --message-system-border: rgba(148, 163, 184, 0.35);
+  --attachment-bg: rgba(248, 250, 252, 0.85);
   --attachment-meta: var(--text-subtle);
   color: var(--text-primary);
-  background-color: #f6ede4;
+  background-color: #eef2ff;
   background-image: var(--bg-gradient);
   transition: background-color 200ms ease, background-image 400ms ease;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg-gradient: radial-gradient(circle at 15% -10%, rgba(255, 170, 92, 0.3), transparent 55%),
-      radial-gradient(circle at 90% 0%, rgba(88, 112, 104, 0.32), transparent 45%),
-      linear-gradient(160deg, #0d0502 0%, #130805 50%, #1a0f0b 100%);
-    background-color: #0d0502;
-    --text-primary: #f6ede4;
-    --text-muted: #d5c4b8;
-    --text-subtle: #c0a899;
-    --text-inverse: #1a0f0b;
-    --surface-primary: rgba(26, 16, 12, 0.82);
-    --surface-secondary: rgba(32, 20, 16, 0.72);
-    --surface-muted: rgba(24, 14, 11, 0.68);
-    --surface-elevated: rgba(34, 22, 17, 0.86);
-    --surface-code: rgba(36, 21, 17, 0.9);
-    --surface-pill: rgba(45, 30, 24, 0.72);
-    --border-strong: rgba(173, 118, 78, 0.6);
-    --border-soft: rgba(173, 118, 78, 0.32);
-    --border-subtle: rgba(173, 118, 78, 0.22);
-    --shadow-lg: 0 52px 110px rgba(4, 1, 0, 0.72);
-    --shadow-md: 0 30px 70px rgba(4, 1, 0, 0.6);
-    --shadow-sm: 0 20px 40px rgba(4, 1, 0, 0.45);
-    --accent: #f2b873;
-    --accent-strong: #d38d3c;
-    --accent-soft: rgba(242, 184, 115, 0.22);
-    --accent-pill-text: #fcebd3;
-    --focus-ring: rgba(242, 184, 115, 0.45);
-    --success: #70d0a8;
-    --success-soft: rgba(112, 208, 168, 0.18);
-    --warning: #f1ae5b;
-    --warning-soft: rgba(241, 174, 91, 0.2);
-    --danger: #f08a7c;
-    --danger-soft: rgba(240, 138, 124, 0.22);
-    --message-user-bg: rgba(28, 44, 40, 0.78);
-    --message-user-border: rgba(112, 208, 168, 0.45);
-    --message-assistant-bg: rgba(52, 34, 24, 0.82);
-    --message-assistant-border: rgba(242, 184, 115, 0.38);
-    --message-system-bg: rgba(40, 26, 20, 0.82);
-    --message-system-border: var(--border-soft);
-    --attachment-bg: rgba(40, 26, 20, 0.78);
-    --attachment-meta: #e7d9ce;
+    --bg-gradient: radial-gradient(circle at 15% -10%, rgba(79, 70, 229, 0.2), transparent 55%),
+      radial-gradient(circle at 90% 0%, rgba(14, 165, 233, 0.2), transparent 45%),
+      linear-gradient(160deg, #020617 0%, #0f172a 45%, #0b1120 100%);
+    background-color: #020617;
+    --text-primary: #e2e8f0;
+    --text-muted: #cbd5f5;
+    --text-subtle: #94a3b8;
+    --text-inverse: #020617;
+    --surface-primary: rgba(15, 23, 42, 0.85);
+    --surface-secondary: rgba(15, 23, 42, 0.78);
+    --surface-muted: rgba(30, 41, 59, 0.65);
+    --surface-elevated: rgba(15, 23, 42, 0.92);
+    --surface-code: rgba(30, 41, 59, 0.9);
+    --surface-shell: rgba(15, 23, 42, 0.86);
+    --panel-gradient: linear-gradient(160deg, #020617 0%, #111827 50%, #0b1120 100%);
+    --panel-border: rgba(99, 102, 241, 0.3);
+    --panel-shadow: 0 40px 80px rgba(2, 6, 23, 0.6);
+    --panel-text: #f8fafc;
+    --panel-text-muted: rgba(226, 232, 240, 0.85);
+    --panel-text-subtle: rgba(148, 163, 184, 0.7);
+    --panel-indicator: rgba(99, 102, 241, 0.8);
+    --border-strong: rgba(99, 102, 241, 0.3);
+    --border-soft: rgba(51, 65, 85, 0.6);
+    --border-subtle: rgba(51, 65, 85, 0.45);
+    --shadow-lg: 0 35px 90px rgba(2, 6, 23, 0.6);
+    --shadow-md: 0 24px 55px rgba(2, 6, 23, 0.45);
+    --shadow-sm: 0 20px 40px rgba(2, 6, 23, 0.35);
+    --accent: #818cf8;
+    --accent-strong: #6366f1;
+    --accent-soft: rgba(129, 140, 248, 0.18);
+    --focus-ring: rgba(129, 140, 248, 0.55);
+    --success: #22d3ee;
+    --success-soft: rgba(34, 211, 238, 0.22);
+    --warning: #facc15;
+    --warning-soft: rgba(250, 204, 21, 0.25);
+    --danger: #f87171;
+    --danger-soft: rgba(248, 113, 113, 0.25);
+    --danger-strong: #fca5a5;
+    --message-user-bg: rgba(22, 78, 99, 0.6);
+    --message-user-border: rgba(45, 212, 191, 0.45);
+    --message-assistant-bg: rgba(54, 47, 120, 0.6);
+    --message-assistant-border: rgba(129, 140, 248, 0.5);
+    --message-system-bg: rgba(30, 41, 59, 0.6);
+    --message-system-border: rgba(71, 85, 105, 0.55);
+    --attachment-bg: rgba(30, 41, 59, 0.75);
+    --attachment-meta: rgba(148, 163, 184, 0.85);
   }
 }
 

--- a/apps/frontend/src/lib/chat/ApprovalPanel.svelte
+++ b/apps/frontend/src/lib/chat/ApprovalPanel.svelte
@@ -30,8 +30,11 @@
 
 <section class="approval" aria-live="polite">
   <header>
-    <h2>Awaiting your approval</h2>
-    <p>Review the draft below. Approve it or request changes with optional feedback.</p>
+    <div>
+      <h2>Awaiting your approval</h2>
+      <p>Review the generated draft, leave feedback, and choose whether to move forward.</p>
+    </div>
+    <span class="badge">Step 3 · Approval</span>
   </header>
 
   {#if previewText}
@@ -54,7 +57,7 @@
   {/if}
 
   <div class="actions">
-    <button type="button" class="secondary" on:click={handleReject} disabled={busy}>
+    <button type="button" class="ghost" on:click={handleReject} disabled={busy}>
       Request changes
     </button>
     <button type="button" on:click={handleApprove} disabled={busy}>
@@ -67,17 +70,19 @@
   .approval {
     display: grid;
     gap: 0.85rem;
-    background: linear-gradient(160deg, var(--surface-primary), var(--surface-secondary));
-    border: 1px solid var(--border-soft);
+    background: var(--surface-primary);
+    border: 1px solid var(--border-strong);
     border-radius: 1.25rem;
     padding: clamp(1rem, 3vw, 1.5rem);
-    box-shadow: inset 0 0 0 1px var(--border-subtle), var(--shadow-md);
+    box-shadow: var(--shadow-md);
     color: var(--text-primary);
   }
 
   header {
-    display: grid;
-    gap: 0.35rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
   }
 
   header h2 {
@@ -91,12 +96,27 @@
     font-size: 0.95rem;
   }
 
+  header .badge {
+    align-self: flex-end;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
   article {
     max-height: 18rem;
     overflow: auto;
     border-radius: 0.85rem;
     border: 1px solid var(--border-subtle);
-    background: var(--surface-muted);
+    background: var(--surface-secondary);
     padding: 0.75rem 1rem;
   }
 
@@ -110,8 +130,8 @@
   textarea {
     width: 100%;
     border-radius: 0.75rem;
-    border: 1px solid var(--border-soft);
-    background: var(--surface-primary);
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-secondary);
     padding: 0.75rem 1rem;
     color: inherit;
     font-size: 1rem;
@@ -144,26 +164,33 @@
   }
 
   button {
-    border-radius: 9999px;
+    border-radius: 0.9rem;
     padding: 0.6rem 1.4rem;
     font-weight: 600;
     cursor: pointer;
+    border: none;
+    transition: transform 150ms ease, box-shadow 150ms ease;
   }
 
-  button.secondary {
+  button.ghost {
     background: transparent;
     border: 1px solid var(--border-subtle);
-    color: var(--text-primary);
+    color: var(--text-muted);
   }
 
-  button:not(.secondary) {
-    background: var(--accent-strong);
-    color: white;
-    border: none;
+  button:not(.ghost) {
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: var(--text-inverse);
+    box-shadow: 0 18px 36px rgba(99, 102, 241, 0.24);
+  }
+
+  button:not(.ghost):hover:not(:disabled) {
+    transform: translateY(-1px);
   }
 
   button:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+    box-shadow: none;
   }
 </style>

--- a/apps/frontend/src/lib/chat/MessageInput.svelte
+++ b/apps/frontend/src/lib/chat/MessageInput.svelte
@@ -7,7 +7,7 @@
 
   export let disabled = false;
   export let pending = false;
-  export let placeholder = "Ask the resume assistant...";
+  export let placeholder = "Share the role, bullet points, or questions...";
   export let allowFileUpload = true;
 
   let content = "";
@@ -92,7 +92,7 @@
         <span class="spinner" aria-hidden="true"></span>
         Sending
       {:else}
-        Send
+        Send message
       {/if}
     </button>
   </div>
@@ -102,25 +102,25 @@
   .message-input {
     display: grid;
     gap: 0.85rem;
-    background: linear-gradient(155deg, var(--surface-elevated), var(--surface-secondary));
-    border: 1px solid var(--border-soft);
+    background: var(--surface-primary);
+    border: 1px solid var(--border-strong);
     border-radius: 1.25rem;
     padding: clamp(1rem, 3vw, 1.35rem);
-    box-shadow: inset 0 0 0 1px var(--border-subtle), var(--shadow-md);
+    box-shadow: var(--shadow-md);
   }
 
   textarea {
     width: 100%;
     resize: vertical;
     min-height: 5rem;
-    border-radius: 0.9rem;
-    border: 1px solid var(--border-soft);
-    background: var(--surface-primary);
+    border-radius: 1rem;
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-secondary);
     color: var(--text-primary);
     padding: 0.85rem 1.1rem;
     font-size: 1rem;
     line-height: 1.55;
-    box-shadow: inset 0 0 0 1px var(--border-subtle);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
     box-sizing: border-box;
     transition: border-color 150ms ease, box-shadow 150ms ease;
   }
@@ -138,25 +138,28 @@
 
   .file-upload {
     display: grid;
-    gap: 0.55rem;
+    gap: 0.6rem;
   }
 
   .upload-button {
+    position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 0.55rem;
-    border-radius: 9999px;
-    background: var(--accent-soft);
+    gap: 0.5rem;
+    border-radius: 0.85rem;
+    padding: 0.45rem 0.9rem;
+    border: 1px dashed rgba(99, 102, 241, 0.35);
+    background: rgba(99, 102, 241, 0.08);
     color: var(--accent-strong);
-    padding: 0.4rem 0.95rem;
-    cursor: pointer;
-    font-size: 0.92rem;
+    font-size: 0.9rem;
     font-weight: 600;
-    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    transition: border-color 150ms ease, background 150ms ease;
   }
 
   .upload-button:hover {
-    filter: brightness(1.05);
+    border-color: var(--accent-strong);
+    background: rgba(99, 102, 241, 0.12);
   }
 
   .upload-button input {
@@ -177,8 +180,8 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.45rem 0.6rem;
-    border-radius: 0.65rem;
-    background: var(--surface-primary);
+    border-radius: 0.75rem;
+    background: var(--surface-secondary);
     font-size: 0.88rem;
     border: 1px solid var(--border-subtle);
     color: var(--text-primary);
@@ -205,9 +208,9 @@
     display: inline-flex;
     align-items: center;
     gap: 0.55rem;
-    border-radius: 9999px;
+    border-radius: 0.9rem;
     border: none;
-    padding: 0.55rem 1.35rem;
+    padding: 0.6rem 1.4rem;
     background: linear-gradient(135deg, var(--accent), var(--accent-strong));
     color: var(--text-inverse);
     font-weight: 700;

--- a/apps/frontend/src/lib/chat/MessageList.svelte
+++ b/apps/frontend/src/lib/chat/MessageList.svelte
@@ -40,7 +40,8 @@
   <div class="messages" bind:this={container} on:scroll={onScroll}>
     {#if messages.length === 0}
       <div class="empty-state">
-        <p>Ask the assistant for help refining your resume or preparing for your next interview.</p>
+        <h3>Your AI workspace is ready</h3>
+        <p>Share the role, paste bullet points, or upload supporting files to get a focused rewrite.</p>
       </div>
     {:else}
       <ul>
@@ -60,7 +61,7 @@
 
   {#if progressItems.length > 0}
     <details class="progress-log">
-      <summary>Detailed workflow updates</summary>
+      <summary>Workflow activity log</summary>
       <ul>
         {#each progressItems as item (item.node + item.timestamp)}
           <li class={item.status}>
@@ -87,13 +88,22 @@
   }
 
   .messages {
-    background: linear-gradient(150deg, var(--surface-secondary), var(--surface-muted));
-    border: 1px solid var(--border-soft);
+    position: relative;
+    background: var(--surface-primary);
+    border: 1px solid var(--border-strong);
     border-radius: 1.25rem;
     padding: clamp(1rem, 2vw, 1.25rem);
     overflow-y: auto;
-    backdrop-filter: blur(18px);
-    box-shadow: inset 0 0 0 1px var(--border-subtle), var(--shadow-md);
+    box-shadow: var(--shadow-md);
+  }
+
+  .messages::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), transparent 70%);
+    pointer-events: none;
   }
 
   .messages ul {
@@ -101,42 +111,62 @@
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.9rem;
+    gap: 1rem;
+    position: relative;
+    z-index: 1;
   }
 
   .empty-state {
+    position: relative;
+    z-index: 1;
     display: grid;
+    gap: 0.5rem;
     place-items: center;
     min-height: 8rem;
-    color: var(--text-muted);
     text-align: center;
-    padding: 1rem;
+    padding: 1.5rem;
+    color: var(--text-muted);
+  }
+
+  .empty-state h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 600;
+  }
+
+  .empty-state p {
+    margin: 0;
+    max-width: 32ch;
+    color: var(--text-subtle);
   }
 
   .typing-indicator {
+    position: relative;
+    z-index: 1;
     display: inline-flex;
-    gap: 0.4rem;
-    padding: 0.55rem 0.85rem;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 0.95rem;
     border-radius: 9999px;
     background: var(--accent-soft);
-    margin-top: 0.6rem;
+    margin-top: 0.75rem;
     box-shadow: var(--shadow-sm);
   }
 
   .typing-indicator .dot {
-    width: 0.45rem;
-    height: 0.45rem;
+    width: 0.4rem;
+    height: 0.4rem;
     border-radius: 50%;
     background: var(--accent-strong);
     animation: pulse 1.2s infinite ease-in-out;
   }
 
   .typing-indicator .dot:nth-child(2) {
-    animation-delay: 0.2s;
+    animation-delay: 0.18s;
   }
 
   .typing-indicator .dot:nth-child(3) {
-    animation-delay: 0.4s;
+    animation-delay: 0.36s;
   }
 
   @keyframes pulse {
@@ -144,21 +174,49 @@
     80%,
     100% {
       transform: scale(0.85);
-      opacity: 0.45;
+      opacity: 0.4;
     }
     40% {
-      transform: scale(1.05);
+      transform: scale(1);
       opacity: 1;
     }
   }
 
   .progress-log {
-    background: linear-gradient(155deg, var(--surface-elevated), var(--surface-secondary));
-    border: 1px solid var(--border-soft);
+    background: var(--surface-secondary);
+    border: 1px solid var(--border-strong);
     border-radius: 1rem;
     padding: 0.85rem 1rem;
-    box-shadow: inset 0 0 0 1px var(--border-subtle);
+    box-shadow: var(--shadow-sm);
     color: var(--text-primary);
+  }
+
+  .progress-log summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    position: relative;
+  }
+
+  .progress-log summary::after {
+    content: "";
+    width: 0.6rem;
+    height: 0.6rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(-45deg);
+    transition: transform 150ms ease;
+  }
+
+  .progress-log[open] summary::after {
+    transform: rotate(45deg);
+  }
+
+  .progress-log summary::-webkit-details-marker {
+    display: none;
   }
 
   .progress-log ul {
@@ -173,13 +231,15 @@
     display: grid;
     gap: 0.35rem;
     padding: 0.6rem 0.75rem;
-    border-radius: 0.75rem;
+    border-radius: 0.85rem;
     background: var(--surface-primary);
     border: 1px solid var(--border-subtle);
+    transition: border-color 150ms ease, box-shadow 150ms ease;
   }
 
   .progress-log li.running {
     border-color: var(--accent-strong);
+    box-shadow: 0 10px 20px rgba(99, 102, 241, 0.12);
   }
 
   .progress-log li.complete {
@@ -202,7 +262,7 @@
 
   .progress-log pre {
     background: var(--surface-muted);
-    border-radius: 0.5rem;
+    border-radius: 0.6rem;
     padding: 0.5rem 0.75rem;
     margin: 0;
     font-size: 0.85rem;

--- a/apps/frontend/src/lib/chat/StreamingMessage.svelte
+++ b/apps/frontend/src/lib/chat/StreamingMessage.svelte
@@ -49,14 +49,25 @@
 
 <style>
   .message {
+    position: relative;
     display: grid;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
+    gap: 0.6rem;
+    padding: 0.95rem 1.2rem;
     border-radius: 1rem;
-    background: var(--surface-primary);
+    background: var(--surface-secondary);
     border: 1px solid var(--border-subtle);
-    box-shadow: var(--shadow-sm);
+    box-shadow: 0 14px 36px rgba(15, 23, 42, 0.08);
     color: var(--text-primary);
+    overflow: hidden;
+  }
+
+  .message::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(120deg, rgba(99, 102, 241, 0.08), transparent 70%);
+    pointer-events: none;
   }
 
   .message.user {
@@ -75,6 +86,8 @@
   }
 
   header {
+    position: relative;
+    z-index: 1;
     display: flex;
     justify-content: space-between;
     align-items: baseline;
@@ -85,14 +98,18 @@
   .role {
     font-weight: 600;
     color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.75rem;
   }
 
   .content {
+    position: relative;
+    z-index: 1;
     font-size: 1rem;
     line-height: 1.6;
     color: inherit;
     word-break: break-word;
-    position: relative;
   }
 
   .content pre,
@@ -109,11 +126,13 @@
   }
 
   .attachments {
+    position: relative;
+    z-index: 1;
     margin: 0;
     padding: 0.5rem 0 0;
     list-style: none;
     display: grid;
-    gap: 0.25rem;
+    gap: 0.35rem;
     font-size: 0.85rem;
     color: var(--text-muted);
   }
@@ -122,8 +141,8 @@
     display: flex;
     justify-content: space-between;
     gap: 0.75rem;
-    padding: 0.35rem 0.5rem;
-    border-radius: 0.5rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 0.6rem;
     background: var(--attachment-bg);
     border: 1px solid var(--border-subtle);
   }
@@ -133,6 +152,8 @@
   }
 
   .error {
+    position: relative;
+    z-index: 1;
     color: var(--danger);
     background: var(--danger-soft);
     border: 1px solid var(--danger);

--- a/apps/frontend/src/lib/chat/WorkflowStatus.svelte
+++ b/apps/frontend/src/lib/chat/WorkflowStatus.svelte
@@ -52,8 +52,11 @@
   <ol>
     {#each steps as step (step.id)}
       <li class={getStepStatus(step.id)}>
-        <span class="label">{step.label}</span>
-        <span class="state">{getStepStatus(step.id)}</span>
+        <span class="marker" aria-hidden="true"></span>
+        <div class="copy">
+          <span class="label">{step.label}</span>
+          <span class="state">{getStepStatus(step.id)}</span>
+        </div>
       </li>
     {/each}
   </ol>
@@ -61,13 +64,13 @@
 
 <style>
   .workflow-status {
-    background: linear-gradient(150deg, var(--surface-secondary), var(--surface-muted));
-    border: 1px solid var(--border-soft);
-    border-radius: 1.1rem;
+    background: var(--surface-primary);
+    border: 1px solid var(--border-strong);
+    border-radius: 1.2rem;
     padding: clamp(1rem, 3vw, 1.4rem);
-    box-shadow: inset 0 0 0 1px var(--border-subtle), var(--shadow-sm);
+    box-shadow: var(--shadow-sm);
     display: grid;
-    gap: 0.75rem;
+    gap: 0.9rem;
     color: var(--text-primary);
   }
 
@@ -75,6 +78,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 0.75rem;
   }
 
   h2 {
@@ -83,24 +87,23 @@
   }
 
   .badge {
-    font-size: 0.85rem;
+    font-size: 0.75rem;
     font-weight: 600;
-    padding: 0.25rem 0.65rem;
+    padding: 0.3rem 0.65rem;
     border-radius: 9999px;
-    background: var(--surface-primary);
-    border: 1px solid var(--border-subtle);
-    text-transform: capitalize;
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
   }
 
   .badge.complete {
     background: var(--success-soft);
-    border-color: var(--success);
     color: var(--success);
   }
 
   .badge.failed {
     background: var(--danger-soft);
-    border-color: var(--danger);
     color: var(--danger);
   }
 
@@ -109,16 +112,18 @@
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.6rem;
+    gap: 0.75rem;
   }
 
   li {
-    display: flex;
-    justify-content: space-between;
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.8rem;
     align-items: center;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.75rem;
-    background: var(--surface-primary);
+    padding: 0.6rem 0.75rem;
+    border-radius: 0.9rem;
+    background: var(--surface-secondary);
     border: 1px solid var(--border-subtle);
     text-transform: capitalize;
     font-size: 0.95rem;
@@ -126,6 +131,7 @@
 
   li.running {
     border-color: var(--accent-strong);
+    box-shadow: 0 12px 24px rgba(99, 102, 241, 0.15);
   }
 
   li.complete {
@@ -138,8 +144,36 @@
     color: var(--danger);
   }
 
+  .marker {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+    background: var(--border-subtle);
+    box-shadow: 0 0 0 6px rgba(148, 163, 184, 0.16);
+  }
+
+  li.running .marker {
+    background: var(--accent-strong);
+    box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.16);
+  }
+
+  li.complete .marker {
+    background: var(--success);
+    box-shadow: 0 0 0 6px rgba(14, 197, 126, 0.18);
+  }
+
+  li.error .marker {
+    background: var(--danger);
+    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0.2);
+  }
+
+  .copy {
+    display: grid;
+    gap: 0.25rem;
+  }
+
   .state {
-    font-size: 0.82rem;
+    font-size: 0.78rem;
     color: var(--text-subtle);
     text-transform: none;
   }


### PR DESCRIPTION
## Summary
- redesign the chat interface with a dual-pane layout that spotlights connection health and onboarding guidance
- refresh message list, input controls, approval view, and workflow tracker to match the new visual language
- update global theme tokens for a modern light/dark palette used across the refreshed components

## Testing
- `mise run frontend.lint`
- `mise run frontend.test`


------
https://chatgpt.com/codex/tasks/task_e_68d5b5c1f2988333b7dd6e31848e94bf