### PR TITLE
test: guard workflow result assertions

### DIFF
--- a/apps/backend/tests/test_workflow.py
+++ b/apps/backend/tests/test_workflow.py
@@ -52,6 +52,7 @@ async def test_resume_workflow_completes():
     )
 
     env = await WorkflowEnvironment.start_time_skipping()
+    result = None
     try:
         activities = list_all_activities()
         async with worker.Worker(
@@ -73,6 +74,9 @@ async def test_resume_workflow_completes():
             result = await handle.result()
     finally:
         await env.shutdown()
+
+    if result is None:
+        pytest.fail("Workflow did not return a result")
 
     assert result.status == "complete"
     assert "published_resume" in result.artifacts


### PR DESCRIPTION
## Summary
- initialize the workflow test result before running the worker to avoid unbound access
- fail explicitly when no workflow result is produced before asserting completion expectations

## Testing
- mise run backend.test -- tests/test_workflow.py::test_resume_workflow_completes

------
https://chatgpt.com/codex/tasks/task_e_68d6f1e376508333b51a2adde0b9b026