### PR TITLE
fix(frontend): handle unexpected empty API responses

### DIFF
--- a/apps/frontend/src/lib/api/resume.test.ts
+++ b/apps/frontend/src/lib/api/resume.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startWorkflow, submitApproval } from "./resume";
+
+describe("resume API client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws a descriptive error when a response is unexpectedly empty", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200, statusText: "OK" }),
+    );
+
+    await expect(startWorkflow({})).rejects.toThrowError(
+      /Expected response body but received empty response/,
+    );
+  });
+
+  it("allows endpoints to opt into empty responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 204, statusText: "No Content" }),
+    );
+
+    await expect(
+      submitApproval("workflow-123", { approved: true }),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- throw explicit errors from resume API client when payloads are unexpectedly empty
- allow the approval submission endpoint to opt into empty responses and cover behavior with new tests

## Testing
- mise run frontend.test -- src/lib/api

------
https://chatgpt.com/codex/tasks/task_e_68d6f1f983188333b084ff2822b59fb1